### PR TITLE
Add gymkhana task_config

### DIFF
--- a/run_trial.bash
+++ b/run_trial.bash
@@ -173,7 +173,7 @@ docker cp --follow-link ${SERVER_CONTAINER_NAME}:/home/$USER/verbose_output.txt 
 
 echo -e "${GREEN}OK${NOCOLOR}\n"
 
-# Record trial score
+# Record trial score. This requires rosbag on host machine
 echo "Creating text file for trial score"
 python ${DIR}/utils/get_trial_score.py $TEAM_NAME $TASK_NAME $TRIAL_NUM
 echo -e "${GREEN}OK${NOCOLOR}\n"

--- a/task_config/gymkhana.yaml
+++ b/task_config/gymkhana.yaml
@@ -41,6 +41,7 @@ tasks:
             gymkhana:
                 - namespace: "cora"
                   competition: "vorc"
+                  nav_name: short_navigation_course_0
                   nav_uri: short_navigation_course0
                   nav_x: 60
                   nav_y: -362

--- a/task_config/gymkhana.yaml
+++ b/task_config/gymkhana.yaml
@@ -1,0 +1,195 @@
+constant:
+    steps: 1
+    macros:
+        marina_minus_scene:
+            -
+    sequence:
+
+tasks:
+    steps: 3
+    macros:
+        ocean_waves:
+            -
+        usv_wind_gazebo:
+            -
+        scene_macro:
+            -
+        gymkhana:
+            -
+    sequence:
+        0:
+            ocean_waves:
+                - gain: 0.0
+                  period: 8.0
+                  scale: 2.6
+            usv_wind_gazebo:
+                - mean_vel: 0.0
+                  var_gain: 0
+                  var_time: 2
+                  seed: 10
+                  topic_wind_speed: "/vorc/debug/wind/speed"
+                  topic_wind_direction: "/vorc/debug/wind/direction"
+                  /**wind_objs: "
+                  <wind_obj>
+                    <name>cora</name>
+                    <link_name>base_link</link_name>
+                    <coeff_vector>.5 .5 .33</coeff_vector>
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "1 1 1 1"
+            gymkhana:
+                - namespace: "cora"
+                  competition: "vorc"
+                  nav_uri: short_navigation_course0
+                  nav_x: 60
+                  nav_y: -362
+                  obs_uri: obstacle_course
+                  obs_x: 140
+                  obs_y: -282
+                  pinger_x: 116
+                  pinger_y: -278
+                  pinger_z: -5
+                  running_duration: 60
+                  /**wp_markers: "
+                  <markers>
+                    <scaling>0.2 0.2 2.0</scaling>
+                    <height>0.5</height>
+                  </markers>"
+                  /**gates: "
+                  <gate>
+                    <left_marker>red_bound_0</left_marker>
+                    <right_marker>green_bound_0</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_1</left_marker>
+                    <right_marker>green_bound_1</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_2</left_marker>
+                    <right_marker>green_bound_2</right_marker>
+                  </gate>"
+        # TODO(anyone): Tweak numbers to make sense for VORC
+        1:
+            ocean_waves:
+                - gain: 0.3
+                  period: 8.0
+                  direction_x: 0.92
+                  direction_y: 0.37
+            usv_wind_gazebo:
+                - mean_vel: 4.0
+                  var_gain: 4
+                  var_time: 10
+                  seed: 10
+                  topic_wind_speed: "/vorc/debug/wind/speed"
+                  topic_wind_direction: "/vorc/debug/wind/direction"
+                  /**wind_objs: "
+                  <wind_obj>
+                    <name>cora</name>
+                    <link_name>base_link</link_name>
+                    <coeff_vector>.5 .5 .33</coeff_vector>
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.9 0.9 0.9 1"
+            gymkhana:
+                - namespace: "cora"
+                  competition: "vorc"
+                  nav_name: vrx_navigation_course_1
+                  nav_uri: navigation_course1
+                  nav_x: 120
+                  nav_y: 87
+                  running_duration: 500
+                  /**gates: "
+                  <gate>
+                    <left_marker>red_bound_0</left_marker>
+                    <right_marker>green_bound_0</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_1</left_marker>
+                    <right_marker>green_bound_1</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_2</left_marker>
+                    <right_marker>green_bound_2</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_3</left_marker>
+                    <right_marker>green_bound_3</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_4</left_marker>
+                    <right_marker>green_bound_4</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_5</left_marker>
+                    <right_marker>green_bound_5</right_marker>
+                  </gate>"
+                  /**wp_markers: "
+                  <markers>
+                    <scaling>0.2 0.2 2.0</scaling>
+                    <height>0.5</height>
+                  </markers>"
+        # TODO(anyone): Tweak numbers to make sense for VORC
+        2:
+            ocean_waves:
+                - gain: 0.7
+                  period: 3
+                  direction_x: 0.37
+                  direction_y: -0.92
+            usv_wind_gazebo:
+                - mean_vel: 8.0
+                  var_gain: 8
+                  var_time: 12
+                  seed: 10
+                  direction: 143
+                  topic_wind_speed: "/vorc/debug/wind/speed"
+                  topic_wind_direction: "/vorc/debug/wind/direction"
+                  /**wind_objs: "
+                  <wind_obj>
+                    <name>cora</name>
+                    <link_name>base_link</link_name>
+                    <coeff_vector>.5 .5 .33</coeff_vector>
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: "
+                  <fog>
+                    <type> linear</type>
+                    <color> 0.7 0.7 0.7 1 </color>
+                    <density> 0.0 </density>
+                  </fog>"
+                  /**ambient: "0.8 0.8 0.8 1"
+            gymkhana:
+                - namespace: "cora"
+                  competition: "vorc"
+                  nav_name: vrx_navigation_course_2
+                  nav_uri: navigation_course2
+                  nav_x: 120
+                  nav_y: 87
+                  running_duration: 600
+                  /**gates: "
+                  <gate>
+                    <left_marker>red_bound_0</left_marker>
+                    <right_marker>green_bound_0</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_1</left_marker>
+                    <right_marker>green_bound_1</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_2</left_marker>
+                    <right_marker>green_bound_2</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_3</left_marker>
+                    <right_marker>green_bound_3</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_4</left_marker>
+                    <right_marker>green_bound_4</right_marker>
+                  </gate>"
+                  /**wp_markers: "
+                  <markers>
+                    <scaling>0.2 0.2 2.0</scaling>
+                    <height>0.5</height>
+                  </markers>"

--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -114,10 +114,9 @@ RUN cd /home/$USER/vorc_ws/src \
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vorc_ws && catkin_make"
 
 # Source all the needed environment files.
-# TODO(mabelzhang): Source from install/setup.bash once fix vrx package setup
 RUN /bin/sh -c 'echo ". /opt/ros/${DIST}/setup.bash" >> ~/.bashrc' \
  && /bin/sh -c 'echo ". /usr/share/gazebo/setup.sh" >> ~/.bashrc' \
- && /bin/sh -c 'echo ". ~/vorc_ws/devel/setup.bash" >> ~/.bashrc'
+ && /bin/sh -c 'echo ". ~/vorc_ws/install/setup.bash" >> ~/.bashrc'
 ## END OF SECTION BASED ON vrx/docker/Dockerfile
 
 # Expose port used to communiate with gzserver

--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -104,20 +104,20 @@ WORKDIR /home/$USER
 # Create workspace
 RUN mkdir -p vorc_ws/src
 
-# TODO(mabelzhang): Clone master branches once merged!
 RUN /bin/sh -c 'echo "Cloning git repos..."'
 RUN cd /home/$USER/vorc_ws/src \
- && git clone -b install_for_docker https://github.com/osrf/vrx.git \
- && git clone -b for_vorc_docker https://github.com/osrf/vorc.git
+ && git clone https://github.com/osrf/vrx.git \
+ && git clone https://github.com/osrf/vorc.git
 
 # Compile VRX and VORC
 #RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vorc_ws && colcon build"
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vorc_ws && catkin_make"
 
 # Source all the needed environment files.
+# TODO(mabelzhang): Source from install/setup.bash once fix vrx package setup
 RUN /bin/sh -c 'echo ". /opt/ros/${DIST}/setup.bash" >> ~/.bashrc' \
  && /bin/sh -c 'echo ". /usr/share/gazebo/setup.sh" >> ~/.bashrc' \
- && /bin/sh -c 'echo ". ~/vorc_ws/install/setup.bash" >> ~/.bashrc'
+ && /bin/sh -c 'echo ". ~/vorc_ws/devel/setup.bash" >> ~/.bashrc'
 ## END OF SECTION BASED ON vrx/docker/Dockerfile
 
 # Expose port used to communiate with gzserver


### PR DESCRIPTION
Adding task_config YAML file for the gymkhana task. Addresses #20 bullet 1.

Creating the PR for visibility so that @crvogt has a base YAML for creating configs for trials > 0.

~~Draft for now, because for some reason the boat cannot be moved. There's probably a bug either in my new gymkhana xacro or in the YAML. Oddly, when I launch the generated .world file, the topic is correct and the boat moves normally.~~ Fixed. Depends on osrf/vorc#31.

To test:
Add the feature branch in osrf/vorc#31 to the `git clone` line in `vorc_server/vorc-server/Dockerfile`:
```diff
- && git clone https://github.com/osrf/vorc.git
+ && git clone -b gymkhana_fix_for_evaluation https://github.com/osrf/vorc.git
```

In `vorc_server/vorc-server/run_vorc_trial.sh`, set `gui:=true` in the `roslaunch vorc_gazebo marina.launch` line, to see the Gazebo GUI during the run.

Then build the Docker image, prepare the gymkhana task, and run the ghostship solution on it:
```
./vorc_server/build_image.bash -n
./prepare_task_trials.bash gymkhana
./run_trial.bash -n ghostship gymkhana 0
```
Check that the example gymkhana navigation channel and obstacle course show up in Gazebo.
After a few seconds of the printout `Sending forward command to cora`, the boat should move forward in the Gazebo GUI.