### PR TITLE
Update github branches in Dockerfile

### DIFF
--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -107,8 +107,8 @@ RUN mkdir -p vorc_ws/src
 # TODO(mabelzhang): Clone master branches once merged!
 RUN /bin/sh -c 'echo "Cloning git repos..."'
 RUN cd /home/$USER/vorc_ws/src \
- && git clone -b install_for_docker https://github.com/osrf/vrx.git \
- && git clone -b for_vorc_docker https://github.com/osrf/vorc.git
+ && git clone https://github.com/osrf/vrx.git \
+ && git clone https://github.com/osrf/vorc.git
 
 # Compile VRX and VORC
 #RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vorc_ws && colcon build"


### PR DESCRIPTION
Updating Dockerfile to clone from `master` branches after osrf/vrx#228 and osrf/vorc#30 were merged into respective `master` branches.

I merged those two PRs before #19, so that I could update #19 before merging. But of course I forgot.