### PR TITLE
Add shipghost team solution

### DIFF
--- a/team_config/shipghost/dockerhub_image.txt
+++ b/team_config/shipghost/dockerhub_image.txt
@@ -1,0 +1,1 @@
+crvogt/shipghost:v1


### PR DESCRIPTION
Add `shipghost` solution discussed in #19 thanks to @crvogt, so that VORC has more than one team to test the multiscripts.

## To test the multiscripts:

(Re)move the `generated/` directory, to start from scratch (so that the team score script doesn’t find extra tasks from previous runs and think a task score is missing):
```
mv generated generated_bak
```

This should prep both `ghostship` and `shipghost` teams:
```
./multi_scripts/prepare_all_teams.bash
```

Prepare just one task so the runs don’t take forever. I picked perception, the quickest to run.
Optionally, you could pick a slower task and manually change the `<running_state_duration>` to a shorter duration (default 300 seconds) in  `generated/task_generated/*/worlds/*.world` files.
```
./prepare_task_trials.bash perception
```

This should run both teams on all trials of the perception task:
```
./multi_scripts/run_all_teams_all_tasks.bash -n
```
This is… quite entertaining, especially the third trial. The boat eventually got flipped by the wind and disappeared in the mist.

## To test the new solution works:
Check that the boat moves backwards in a task that doesn’t lock the boat (i.e. not perception):
```
./prepare_task_trials.bash wayfinding
# Optionally, shorten duration in generated/task_generated/wayfinding/worlds/wayfinding0.world to <running_state_duration>60
./run_trial.bash -n shipghost wayfinding 0
```
