### PR TITLE
Remove VRX_EXIT_ON_COMPLETION flag from VORC

### DIFF
--- a/run_trial.bash
+++ b/run_trial.bash
@@ -136,7 +136,6 @@ ${DIR}/vorc_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERV
   -v ${HOST_LOG_DIR}:${LOG_DIR} \
   -e ROS_MASTER_URI=${ROS_MASTER_URI} \
   -e ROS_IP=${SERVER_ROS_IP} \
-  -e VRX_EXIT_ON_COMPLETION=true \
   -e VRX_DEBUG=false" \
   "${SERVER_CMD}" &
 SERVER_PID=$!


### PR DESCRIPTION
Removes `VRX_EXIT_ON_COMPLETION` environment variable from `run_trial.bash`, so that the new SDF shutdown flag added in https://github.com/osrf/vorc/pull/35 are respected.
(This change is needed because currently, the environment variable overwrites SDF parameters, by design. See https://github.com/osrf/vorc/pull/35.)

What I have tested using the 2 branches in the pending PR above:
- Gymkhana, to make sure container doesn't shut down after the gates
- Stationkeeping, wayfinding, and perception, to make sure the container still shuts down