### PR TITLE
Play back trial from within Docker container instead of host machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ A side effect is that it will shut down if the playback is paused (which happens
 
 To inspect more carefully, you may wish to pause playback without Gazebo shutting down.
 That can be done by issuing `--keep-gz` on the command line:
-
 ```
 ./replay_trial.bash -n --keep-gz ghostship wayfinding 0
 ```
@@ -315,7 +314,7 @@ docker exec -it vorc-server-system killall -w gzclient gzserver
 ```
 The autopilot will detect Gazebo termination and shut down the rest of the container.
 
-`replay_trial.bash accepts a few options for more manual inspections, which you can view in the usage by running it alone without arguments.
+`replay_trial.bash` accepts a few options for more manual inspections, which you can view in the usage by running it alone without arguments.
 
 ### Generating a single trial video
 

--- a/README.md
+++ b/README.md
@@ -289,20 +289,29 @@ cat generated/logs/ghostship/stationkeeping/0/trial_score.txt
 
 ## Quick Start Instructions For a Single Trial: Trial videos and playback
 
-### Generating a single trial video
+### Playing back the recorded log of a single trial
 
 After running a trial, a `state.log` file is stored under `generated/logs/<team>/<task>/<trial_num>/gazebo-server`. This is a playback log file that allows you to play back the trial. 
-To generate a trial video, please run the trial using the steps above, source vorc, and then run
+
+To play back the trial with Gazebo GUI from within the competition Docker container, run
 
 ```
-./generate_trial_video.bash ghostship stationkeeping 0
+./replay_trial.bash -n example_team station_keeping 0
+```
+
+### Generating a single trial video
+
+To make a screen recording of the trial while playing back, run the following command. Internally, this calls `replay_trial.bash` above.
+
+```
+./generate_trial_video.bash -n ghostship stationkeeping 0
 
 # For your team you will run:
-# ./generate_trial_video.bash <your_team_name> <task_name> <trial_number>
+# ./generate_trial_video.bash -n <your_team_name> <task_name> <trial_number>
 ```
 
 This will start the Gazebo trial playback, begin screen capture on the Gazebo window, and then store the video file, record output and playback output in `generated/logs/<team>/<task>/<trial_num>/video`. 
-Please note that you must close other tabs related to Gazebo for this to work properly, as it puts the Gazebo window at the front (not background). If you have a browser tab open related to Gazebo,
+Please note that you must close other tabs related to Gazebo for this to work properly, as it puts the Gazebo window at the front (not background). Keep the Gazebo window on top. If you have a browser tab open related to Gazebo,
 it may find that window, instead of the actual Gazebo simulation window.
 
 There should be a new directory called `generated/logs/<team>/<task>/<trial_num>/video` that contains the following:

--- a/README.md
+++ b/README.md
@@ -296,8 +296,26 @@ After running a trial, a `state.log` file is stored under `generated/logs/<team>
 To play back the trial with Gazebo GUI from within the competition Docker container, run
 
 ```
-./replay_trial.bash -n example_team station_keeping 0
+./replay_trial.bash -n ghostship stationkeeping 0
 ```
+
+By default, this is on autopilot and will shut down Gazebo after log playback is finished.
+A side effect is that it will shut down if the playback is paused (which happens to be an indication of the log playback having finished).
+
+To inspect more carefully, you may wish to pause playback without Gazebo shutting down.
+That can be done by issuing `--keep-gz` on the command line:
+
+```
+./replay_trial.bash -n --keep-gz ghostship wayfinding 0
+```
+
+When you are done with manual inspection, you can shut down Gazebo cleanly by issuing this to the container:
+```
+docker exec -it vorc-server-system killall -w gzclient gzserver
+```
+The autopilot will detect Gazebo termination and shut down the rest of the container.
+
+`replay_trial.bash accepts a few options for more manual inspections, which you can view in the usage by running it alone without arguments.
 
 ### Generating a single trial video
 

--- a/generate_trial_video.bash
+++ b/generate_trial_video.bash
@@ -156,6 +156,9 @@ sleep 9s
 
 echo "Setting up screen recording..."
 
+ADVERTISE_CMD="bash /home/master/vorc_ws/install/setup.bash && rostopic pub /record_ready std_msgs/Bool 0"
+docker exec -it ${SERVER_CONTAINER_NAME} ${ADVERTISE_CMD}
+
 # Wait and find the Gazebo Window ID.
 # Note: May find Gazebo in browser tab, which is wrong. Please close all Gazebo related tabs.
 until wmctrl -lp | grep Gazebo > /dev/null
@@ -177,10 +180,10 @@ wmctrl -i -a ${GAZEBO_WINDOW_ID}
 # screen for a long time.
 sleep $BLACK_WINDOW_TIME
 
-# Unpause the simulation.
-echo -n "Unpausing Gazebo..."
+# Unpause the simulation right before starting recordmydesktop
+echo "Injecting signal to unpause Gazebo..."
 # Inject command into Docker container
-UNPAUSE_CMD="gz world -p 0"
+UNPAUSE_CMD="bash /home/master/vorc_ws/install/setup.bash && rostopic pub /record_ready std_msgs/Bool 1"
 docker exec -it ${SERVER_CONTAINER_NAME} ${UNPAUSE_CMD}
 echo -e "${GREEN}OK${NOCOLOR}"
 
@@ -190,7 +193,7 @@ recordmydesktop --fps=30 --windowid=${GAZEBO_WINDOW_ID} --no-sound -o $HOST_OUTP
   > $HOST_OUTPUT.record_output.txt 2>&1 #&
 echo -e "${GREEN}OK${NOCOLOR}"
 
-echo -n "Encoding video and storing in $OUTPUT ..."
+echo "Encoding video and storing in $OUTPUT ..."
 killall -w recordmydesktop
 echo -e "${GREEN}OK${NOCOLOR}"
 

--- a/generate_trial_video.bash
+++ b/generate_trial_video.bash
@@ -20,11 +20,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # clean up processes, as we will do that later in this script.
 # Specify --manual-play to start playback from this script after screen
 # recording is ready to begin.
-# Specify --keep-gz to keep Gazebo client window open until screen recording
-# stops.
-# TODO: leaving --keep-gz out for now, cannot detect playback ended from here
-# for some reason, so Docker injection to kill Gazebo is not being issued.
-# Letting play_vorc_log.sh terminate Gazebo until this is fixed.
 source ${DIR}/replay_trial.bash --keep-docker --manual-play "$@"
 
 echo "Setting up screen recording..."
@@ -65,51 +60,6 @@ echo "Injecting signal into Docker container to unpause Gazebo..."
 UNPAUSE_CMD="gz world -p 0"
 docker exec -it ${SERVER_CONTAINER_NAME} ${UNPAUSE_CMD}
 echo -e "${GREEN}OK${NOCOLOR}"
-
-# TODO: leaving --keep-gz out for now, cannot detect playback ended from here
-# for some reason, so Docker injection to kill Gazebo is not being issued.
-# Letting play_vorc_log.sh terminate Gazebo until this is fixed.
-## Check if gzclient is running
-#is_gzclient_running()
-#{
-#  if docker exec -it ${SERVER_CONTAINER_NAME} pgrep gzclient > /dev/null; then
-#    true
-#  else
-#    false
-#  fi
-#}
-#
-## Wait until the gazebo world stats topic (eg. /gazebo/<world>/world_stats)
-## tells us that the playback has been paused. This event will trigger the end of
-## the recording.
-#wait_until_playback_ends()
-#{
-#  echo "Waiting for playback in container [${SERVER_CONTAINER_NAME}] to end..."
-#  gz_world_stats_topic=$(docker exec -it ${SERVER_CONTAINER_NAME} gz topic -l | grep "world_stats")
-#
-#  # Sleep until Gazebo is paused
-#  until docker exec -it ${SERVER_CONTAINER_NAME} gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: true" --quiet
-#  do
-#
-#    # DEBUG
-#    docker exec -it ${SERVER_CONTAINER_NAME} gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: true"
-#
-#    sleep 1
-#    if ! is_gzclient_running ; then
-#      echo "Detected gzclient no longer running in container"
-#      return 0
-#    fi
-#  done
-#  echo -e "${GREEN}OK${NOCOLOR}"
-#}
-#
-#wait_until_playback_ends
-#
-## Terminate Gazebo only after recording ends, so that we don't record the screen
-## content behind the Gazebo window.
-#echo "Injecting signal into Docker container to terminate Gazebo..."
-#docker exec -it ${SERVER_CONTAINER_NAME} killall -w gzserver gzclient
-#echo -e "${GREEN}OK${NOCOLOR}"
 
 # Wait for Docker container to terminate
 echo "Waiting for Docker container to terminate..."

--- a/generate_trial_video.bash
+++ b/generate_trial_video.bash
@@ -85,10 +85,10 @@ LOG_FILE=${LOG_DIR}${LOG_SUFFIX}
 HOST_LOG_FILE=${HOST_LOG_DIR}${LOG_SUFFIX}
 # Sanity check: Make sure that the log file exists.
 if [ ! -f $HOST_LOG_FILE ]; then
-    echo "Gazebo log file [$HOST_LOG_FILE] not found!"
-    exit 1
+  echo "Gazebo log file [$HOST_LOG_FILE] not found!"
+  exit 1
 else
-    echo "Found Gazebo log file [$HOST_LOG_FILE]"
+  echo "Found Gazebo log file [$HOST_LOG_FILE]"
 fi
 
 # Output directory

--- a/generate_trial_video.bash
+++ b/generate_trial_video.bash
@@ -1,158 +1,31 @@
 #!/bin/bash
 
-# generate_trial_video.bash: A bash script to generate a video from a Gazebo playback log file.
+# generate_trial_video.bash: A bash script to generate a video from a Gazebo
+# playback log file.
+#
 # Input: Gazebo log file state.log
 # Output: Recorded video in .ogv
 #
-# E.g.: ./generate_trial_video.bash -n example_team station_keeping 0
+# Usage:
+# ./generate_trial_video.bash -n example_team station_keeping 0
 #
-# Please, install the following dependencies before using the script:
+# Please install the following dependencies before using the script:
 #   sudo apt-get install recordmydesktop wmctrl psmisc
-
-# Exit on error
-set -e
-
-# Constants
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-NOCOLOR='\033[0m'
-
-# Define usage function.
-usage()
-{
-  echo "Usage: $0 [-n --nvidia] <team_name> <task_name> <trial_num>"
-  exit 1
-}
-
-# Parse arguments
-nvidia_arg=""
-image_nvidia=""
-
-POSITIONAL=()
-while [[ $# -gt 0 ]]
-do
-  key="$1"
-
-  case $key in
-      -n|--nvidia)
-      nvidia_arg="-n"
-      image_nvidia="-nvidia"
-      shift
-      ;;
-      *)    # unknown option
-      POSITIONAL+=("$1")
-      shift
-      ;;
-  esac
-done
-
-set -- "${POSITIONAL[@]}"
-
-# Call usage() function if arguments not supplied.
-[[ $# -ne 3 ]] && usage
-
-TEAM_NAME=$1
-TASK_NAME=$2
-TRIAL_NUM=$3
-
-# Constants for containers
-SERVER_CONTAINER_NAME=vorc-server-system
-ROS_DISTRO=melodic
-LOG_DIR=/vorc/logs
-NETWORK=vorc-network
-NETWORK_SUBNET="172.16.0.10/16" # subnet mask allows communication between IP addresses with 172.16.xx.xx (xx = any)
-SERVER_ROS_IP="172.16.0.22"
-COMPETITOR_ROS_IP="172.16.0.20"
-ROS_MASTER_URI="http://${SERVER_ROS_IP}:11311"
 
 # Get directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Create the network for the containers to talk to each other.
-${DIR}/utils/vorc_network.bash "${NETWORK}" "${NETWORK_SUBNET}"
-
-echo "Playing back $TEAM_NAME solution in $TASK_NAME $TRIAL_NUM"
-echo -e "=================================\n"
-
-echo "Setting up"
-echo "---------------------------------"
-
-# Input file
-HOST_LOG_DIR=${DIR}/generated/logs/${TEAM_NAME}/${TASK_NAME}/${TRIAL_NUM}
-LOG_SUFFIX=/gazebo-server/state.log
-LOG_FILE=${LOG_DIR}${LOG_SUFFIX}
-HOST_LOG_FILE=${HOST_LOG_DIR}${LOG_SUFFIX}
-# Sanity check: Make sure that the log file exists.
-if [ ! -f $HOST_LOG_FILE ]; then
-  echo "Gazebo log file [$HOST_LOG_FILE] not found!"
-  exit 1
-else
-  echo "Found Gazebo log file [$HOST_LOG_FILE]"
-fi
-
-# Output directory
-HOST_OUTPUT_DIR=${HOST_LOG_DIR}/video
-OUTPUT_DIR=${LOG_DIR}/video
-if [ -d "$HOST_OUTPUT_DIR" ]; then
-  echo "Overwriting directory: ${HOST_OUTPUT_DIR}"
-  rm -R $HOST_OUTPUT_DIR
-else
-  echo "Creating directory: ${HOST_OUTPUT_DIR}"
-fi
-
-mkdir -p $HOST_OUTPUT_DIR
-OUTPUT_SUFFIX=/playback_video.ogv
-HOST_OUTPUT=$HOST_OUTPUT_DIR$OUTPUT_SUFFIX
-OUTPUT=$OUTPUT_DIR$OUTPUT_SUFFIX
-
-# Ensure any previous containers are killed and removed.
-${DIR}/utils/kill_vorc_containers.bash
-
-echo "Starting simulation server container for playback"
-echo "-------------------------------------------------"
-
-# Define constants for recording
-x=100
-y=100
-width=1000
-height=750
-BLACK_WINDOW_TIME=2
-
-HOST_GZ_GUI_CONFIG_DIR=${DIR}/generated/logs/playback_gazebo
-GZ_GUI_CONFIG_DIR=/home/$USER/.gazebo
-if [ -d "$HOST_GZ_GUI_CONFIG_DIR" ]; then
-  echo "Overwriting directory: ${HOST_GZ_GUI_CONFIG_DIR}"
-  rm -R $HOST_GZ_GUI_CONFIG_DIR
-else
-  echo "Creating directory: ${HOST_GZ_GUI_CONFIG_DIR}"
-fi
-mkdir -p $HOST_GZ_GUI_CONFIG_DIR
-
-# Tell gazebo client what size and place it should be
-echo "[geometry]
-width=$width
-height=$height
-x=$x
-y=$y" > ${HOST_GZ_GUI_CONFIG_DIR}/gui.ini
-
-# Run Gazebo simulation server container
-SERVER_CMD="/play_vorc_log.sh ${LOG_FILE} ${OUTPUT}"
-SERVER_IMG="vorc-server-${ROS_DISTRO}${image_nvidia}:latest"
-${DIR}/vorc_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERVER_IMG \
-  "--net ${NETWORK} \
-  --ip ${SERVER_ROS_IP} \
-  -v ${HOST_LOG_DIR}:${LOG_DIR} \
-  -v ${HOST_OUTPUT_DIR}:${OUTPUT_DIR} \
-  -v ${HOST_GZ_GUI_CONFIG_DIR}:${GZ_GUI_CONFIG_DIR} \
-  -e ROS_MASTER_URI=${ROS_MASTER_URI} \
-  -e ROS_IP=${SERVER_ROS_IP} \
-  -e VRX_DEBUG=false" \
-  "${SERVER_CMD}" &
-SERVER_PID=$!
-
-echo "Waiting for server to start up"
-sleep 9s
+# Play back the log file.
+# Specify --keep-docker so that it doesn't block for container to terminate and
+# clean up processes, as we will do that later in this script.
+# Specify --manual-play to start playback from this script after screen
+# recording is ready to begin.
+# Specify --keep-gz to keep Gazebo client window open until screen recording
+# stops.
+# TODO: leaving --keep-gz out for now, cannot detect playback ended from here
+# for some reason, so Docker injection to kill Gazebo is not being issued.
+# Letting play_vorc_log.sh terminate Gazebo until this is fixed.
+source ${DIR}/replay_trial.bash --keep-docker --manual-play "$@"
 
 echo "Setting up screen recording..."
 
@@ -177,28 +50,73 @@ wmctrl -i -a ${GAZEBO_WINDOW_ID}
 # screen for a long time.
 sleep $BLACK_WINDOW_TIME
 
-# Unpause the simulation right before starting recordmydesktop
-echo "Injecting signal to unpause Gazebo..."
-# Inject command into Docker container
-#UNPAUSE_CMD="bash /home/master/vorc_ws/install/setup.bash && rostopic pub /host_ready std_msgs/Bool 1"
-UNPAUSE_CMD="bash /home/master/vorc_ws/install/setup.bash && rosparam set /host_ready 1"
-for i in {0..9}
-do
-  docker exec -it ${SERVER_CONTAINER_NAME} ${UNPAUSE_CMD}
-  sleep 0.2
-done
-echo -e "${GREEN}OK${NOCOLOR}"
-
 # Start recording the Gazebo Window.
-echo "Recording screen..."
+echo "Recording screen on host..."
 recordmydesktop --fps=30 --windowid=${GAZEBO_WINDOW_ID} --no-sound -o $HOST_OUTPUT \
   > $HOST_OUTPUT.record_output.txt 2>&1 &
 echo -e "${GREEN}OK${NOCOLOR}"
 
-# Wait for Docker container to terminate
-wait $SERVER_PID
+# Give Gazebo time to finish starting up
+sleep 3s
 
-echo "Encoding video and storing in $OUTPUT ..."
+# Unpause the simulation to begin playback
+echo "Injecting signal into Docker container to unpause Gazebo..."
+# Inject unpause command into Docker container
+UNPAUSE_CMD="gz world -p 0"
+docker exec -it ${SERVER_CONTAINER_NAME} ${UNPAUSE_CMD}
+echo -e "${GREEN}OK${NOCOLOR}"
+
+# TODO: leaving --keep-gz out for now, cannot detect playback ended from here
+# for some reason, so Docker injection to kill Gazebo is not being issued.
+# Letting play_vorc_log.sh terminate Gazebo until this is fixed.
+## Check if gzclient is running
+#is_gzclient_running()
+#{
+#  if docker exec -it ${SERVER_CONTAINER_NAME} pgrep gzclient > /dev/null; then
+#    true
+#  else
+#    false
+#  fi
+#}
+#
+## Wait until the gazebo world stats topic (eg. /gazebo/<world>/world_stats)
+## tells us that the playback has been paused. This event will trigger the end of
+## the recording.
+#wait_until_playback_ends()
+#{
+#  echo "Waiting for playback in container [${SERVER_CONTAINER_NAME}] to end..."
+#  gz_world_stats_topic=$(docker exec -it ${SERVER_CONTAINER_NAME} gz topic -l | grep "world_stats")
+#
+#  # Sleep until Gazebo is paused
+#  until docker exec -it ${SERVER_CONTAINER_NAME} gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: true" --quiet
+#  do
+#
+#    # DEBUG
+#    docker exec -it ${SERVER_CONTAINER_NAME} gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: true"
+#
+#    sleep 1
+#    if ! is_gzclient_running ; then
+#      echo "Detected gzclient no longer running in container"
+#      return 0
+#    fi
+#  done
+#  echo -e "${GREEN}OK${NOCOLOR}"
+#}
+#
+#wait_until_playback_ends
+#
+## Terminate Gazebo only after recording ends, so that we don't record the screen
+## content behind the Gazebo window.
+#echo "Injecting signal into Docker container to terminate Gazebo..."
+#docker exec -it ${SERVER_CONTAINER_NAME} killall -w gzserver gzclient
+#echo -e "${GREEN}OK${NOCOLOR}"
+
+# Wait for Docker container to terminate
+echo "Waiting for Docker container to terminate..."
+wait $SERVER_PID
+echo -e "${GREEN}OK${NOCOLOR}"
+
+echo "Encoding video and storing in $OUTPUT before terminating Gazebo..."
 killall -w recordmydesktop
 echo -e "${GREEN}OK${NOCOLOR}"
 

--- a/replay_trial.bash
+++ b/replay_trial.bash
@@ -7,9 +7,6 @@
 #
 # Usage:
 # ./replay_trial.bash -n example_team station_keeping 0
-#
-# Dependencies:
-# sudo apt-get install psmisc
 
 # Exit on error
 set -e

--- a/replay_trial.bash
+++ b/replay_trial.bash
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# replay_trial.bash: Replay a trial recorded to a Gazebo log file, e.g.
+# state.log.
+#
+# Input: Gazebo log file state.log
+#
+# Usage:
+# ./replay_trial.bash -n example_team station_keeping 0
+# --keep-open: Keeps Gazebo window open and Docker container running after
+# playback ends.
+#
+# Dependencies:
+# sudo apt-get install psmisc
+
+# Exit on error
+set -e
+
+# Constants
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
+
+# Define usage function.
+usage()
+{
+  echo "Usage: $0 [-n --nvidia] [--keep-open] <team_name> <task_name> <trial_num>"
+  exit 1
+}
+
+# Parse arguments
+nvidia_arg=""
+image_nvidia=""
+terminate=1
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+
+  case $key in
+    -n|--nvidia)
+      nvidia_arg="-n"
+      image_nvidia="-nvidia"
+      shift
+      ;;
+      *)    # unknown option
+      POSITIONAL+=("$1")
+      shift
+      ;;
+
+    --keep-open)
+      terminate=0
+      shift
+      ;;
+      *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL[@]}"
+
+# Call usage() function if arguments not supplied.
+[[ $# -ne 3 ]] && usage
+
+TEAM_NAME=$1
+TASK_NAME=$2
+TRIAL_NUM=$3
+
+# Constants for containers
+SERVER_CONTAINER_NAME=vorc-server-system
+ROS_DISTRO=melodic
+LOG_DIR=/vorc/logs
+NETWORK=vorc-network
+NETWORK_SUBNET="172.16.0.10/16" # subnet mask allows communication between IP addresses with 172.16.xx.xx (xx = any)
+SERVER_ROS_IP="172.16.0.22"
+COMPETITOR_ROS_IP="172.16.0.20"
+ROS_MASTER_URI="http://${SERVER_ROS_IP}:11311"
+
+# Get directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Create the network for the containers to talk to each other.
+${DIR}/utils/vorc_network.bash "${NETWORK}" "${NETWORK_SUBNET}"
+
+echo "Playing back $TEAM_NAME solution in $TASK_NAME $TRIAL_NUM"
+echo -e "=================================\n"
+
+echo "Setting up"
+echo "---------------------------------"
+
+# Input file
+HOST_LOG_DIR=${DIR}/generated/logs/${TEAM_NAME}/${TASK_NAME}/${TRIAL_NUM}
+LOG_SUFFIX=/gazebo-server/state.log
+LOG_FILE=${LOG_DIR}${LOG_SUFFIX}
+HOST_LOG_FILE=${HOST_LOG_DIR}${LOG_SUFFIX}
+# Sanity check: Make sure that the log file exists.
+if [ ! -f $HOST_LOG_FILE ]; then
+  echo "Gazebo log file [$HOST_LOG_FILE] not found!"
+  exit 1
+else
+  echo "Found Gazebo log file [$HOST_LOG_FILE]"
+fi
+
+# Output directory
+HOST_OUTPUT_DIR=${HOST_LOG_DIR}/video
+OUTPUT_DIR=${LOG_DIR}/video
+if [ -d "$HOST_OUTPUT_DIR" ]; then
+  echo "Overwriting directory: ${HOST_OUTPUT_DIR}"
+  rm -R $HOST_OUTPUT_DIR
+else
+  echo "Creating directory: ${HOST_OUTPUT_DIR}"
+fi
+
+mkdir -p $HOST_OUTPUT_DIR
+OUTPUT_SUFFIX=/playback_video.ogv
+HOST_OUTPUT=$HOST_OUTPUT_DIR$OUTPUT_SUFFIX
+OUTPUT=$OUTPUT_DIR$OUTPUT_SUFFIX
+
+# Ensure any previous containers are killed and removed.
+${DIR}/utils/kill_vorc_containers.bash
+
+echo "Starting simulation server container for playback"
+echo "-------------------------------------------------"
+
+# Define constants for recording
+x=100
+y=100
+width=1000
+height=750
+BLACK_WINDOW_TIME=2
+
+HOST_GZ_GUI_CONFIG_DIR=${DIR}/generated/logs/playback_gazebo
+GZ_GUI_CONFIG_DIR=/home/$USER/.gazebo
+if [ -d "$HOST_GZ_GUI_CONFIG_DIR" ]; then
+  echo "Overwriting directory: ${HOST_GZ_GUI_CONFIG_DIR}"
+  rm -R $HOST_GZ_GUI_CONFIG_DIR
+else
+  echo "Creating directory: ${HOST_GZ_GUI_CONFIG_DIR}"
+fi
+mkdir -p $HOST_GZ_GUI_CONFIG_DIR
+
+# Tell gazebo client what size and place it should be
+echo "[geometry]
+width=$width
+height=$height
+x=$x
+y=$y" > ${HOST_GZ_GUI_CONFIG_DIR}/gui.ini
+
+# Run Gazebo simulation server container
+SERVER_CMD="/play_vorc_log.sh ${LOG_FILE} ${OUTPUT}"
+SERVER_IMG="vorc-server-${ROS_DISTRO}${image_nvidia}:latest"
+${DIR}/vorc_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERVER_IMG \
+  "--net ${NETWORK} \
+  --ip ${SERVER_ROS_IP} \
+  -v ${HOST_LOG_DIR}:${LOG_DIR} \
+  -v ${HOST_OUTPUT_DIR}:${OUTPUT_DIR} \
+  -v ${HOST_GZ_GUI_CONFIG_DIR}:${GZ_GUI_CONFIG_DIR} \
+  -e ROS_MASTER_URI=${ROS_MASTER_URI} \
+  -e ROS_IP=${SERVER_ROS_IP} \
+  -e VRX_DEBUG=false" \
+  "${SERVER_CMD}" &
+SERVER_PID=$!
+
+#echo "Waiting for server to start up"
+#sleep 9s
+
+if [ $terminate -eq 1 ]; then
+  # Wait for Docker container to terminate
+  wait $SERVER_PID
+
+  echo "Playback ended"
+  echo "---------------------------------"
+
+  # Kill and remove all containers before exit
+  ${DIR}/utils/kill_vorc_containers.bash
+
+  exit 0
+fi

--- a/replay_trial.bash
+++ b/replay_trial.bash
@@ -7,8 +7,6 @@
 #
 # Usage:
 # ./replay_trial.bash -n example_team station_keeping 0
-# --keep-open: Keeps Gazebo window open and Docker container running after
-# playback ends.
 #
 # Dependencies:
 # sudo apt-get install psmisc
@@ -26,8 +24,12 @@ NOCOLOR='\033[0m'
 usage()
 {
   echo "Usage: $0 [-n --nvidia] [--keep-open] <team_name> <task_name> <trial_num>"
+  echo "--keep-open: Keep Gazebo window open and Docker container running after playback ends."
   exit 1
 }
+
+# Call usage() function if arguments not supplied.
+[[ $# -lt 3 ]] && echo "Invalid arguments: $@" && usage
 
 # Parse arguments
 nvidia_arg=""
@@ -45,16 +47,14 @@ do
       image_nvidia="-nvidia"
       shift
       ;;
-      *)    # unknown option
-      POSITIONAL+=("$1")
-      shift
-      ;;
 
     --keep-open)
       terminate=0
       shift
       ;;
-      *)
+
+    # Treat unknown options as positional args
+    *)
       POSITIONAL+=("$1")
       shift
       ;;
@@ -62,9 +62,6 @@ do
 done
 
 set -- "${POSITIONAL[@]}"
-
-# Call usage() function if arguments not supplied.
-[[ $# -ne 3 ]] && usage
 
 TEAM_NAME=$1
 TASK_NAME=$2
@@ -164,9 +161,6 @@ ${DIR}/vorc_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERV
   -e VRX_DEBUG=false" \
   "${SERVER_CMD}" &
 SERVER_PID=$!
-
-#echo "Waiting for server to start up"
-#sleep 9s
 
 if [ $terminate -eq 1 ]; then
   # Wait for Docker container to terminate

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -54,6 +54,13 @@ TEAM_NAME=$1
 TASK_NAME=$2
 TRIAL_NUM=$3
 
+# Check ROS has been sourced, so user isn't surprised after trial has finished
+if rosversion -d | grep unknown --quiet ; then
+  echo "rosbag is not found (needed for trial score after the run)."
+  echo "Did you source ROS on host machine?"
+  exit
+fi
+
 # Constants for containers
 SERVER_CONTAINER_NAME=vorc-server-system
 ROS_DISTRO=melodic

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -93,10 +93,10 @@ COMP_GENERATED_DIR=${DIR}/generated/task_generated/${TASK_NAME}
 WORLD_FILE_SUFFIX=worlds/${TASK_NAME}${TRIAL_NUM}.world
 if [ -f "${COMP_GENERATED_DIR}/${WORLD_FILE_SUFFIX}" ]; then
   echo "Successfully found: ${COMP_GENERATED_DIR}/${WORLD_FILE_SUFFIX}"
+  echo -e "${GREEN}Done.${NOCOLOR}\n"
 else
   echo -e "${RED}Err: ${COMP_GENERATED_DIR}/${WORLD_FILE_SUFFIX} not found."; exit 1;
 fi
-echo -e "${GREEN}Done.${NOCOLOR}\n"
 
 # Ensure any previous containers are killed and removed.
 ${DIR}/utils/kill_vorc_containers.bash
@@ -123,8 +123,9 @@ docker image pull $DOCKERHUB_IMAGE
 echo "Starting simulation server container"
 echo "---------------------------------"
 
-# TODO: Figure out if we can start competitor container first, so simulation doesn't start too early, but may have issues if
-#       competitior container waiting for ROS master and has error before server is created.
+# TODO(anyone): Figure out if we can start competitor container first, so
+# simulation doesn't start too early, but may have issues if competitior
+# container waiting for ROS master and has error before server is created.
 # Run Gazebo simulation server container
 WORLD_FILE=/task_generated/${WORLD_FILE_SUFFIX}
 SERVER_CMD="/run_vorc_trial.sh ${WORLD_FILE} ${LOG_DIR}"

--- a/vorc_server/build_image.bash
+++ b/vorc_server/build_image.bash
@@ -62,10 +62,9 @@ fi
 # Build image
 echo "Build image: $image_name"
 set -x
-#image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
-image_plus_tag=$image_name:latest
+image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
 docker build --force-rm ${DOCKER_ARGS} --tag $image_plus_tag --build-arg USER=$USER --build-arg GROUP=$USER $BUILD_BASE $DIR/vorc-server && \
-#docker tag $image_plus_tag $image_name:latest && \
+docker tag $image_plus_tag $image_name:latest && \
 echo "Built $image_plus_tag and tagged as $image_name:latest"
 
 set +x

--- a/vorc_server/build_image.bash
+++ b/vorc_server/build_image.bash
@@ -62,9 +62,10 @@ fi
 # Build image
 echo "Build image: $image_name"
 set -x
-image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
+#image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
+image_plus_tag=$image_name:latest
 docker build --force-rm ${DOCKER_ARGS} --tag $image_plus_tag --build-arg USER=$USER --build-arg GROUP=$USER $BUILD_BASE $DIR/vorc-server && \
-docker tag $image_plus_tag $image_name:latest && \
+#docker tag $image_plus_tag $image_name:latest && \
 echo "Built $image_plus_tag and tagged as $image_name:latest"
 
 set +x

--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -137,7 +137,7 @@ ENV LANG en_US.UTF-8
 #  && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
 #  && rm /tmp/default.tar.gz
 
-#RUN sudo apt-get install -y psmisc
+RUN sudo apt-get install -y psmisc
 
 # setup entrypoint
 COPY ./vorc_entrypoint.sh /

--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -32,6 +32,7 @@ RUN apt update \
          libeigen3-dev \
          pkg-config \
          language-pack-en \
+         psmisc \
   && apt clean
 
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -107,7 +108,7 @@ RUN mkdir -p vorc_ws/src
 RUN /bin/sh -c 'echo "Cloning git repos..."'
 RUN cd /home/$USER/vorc_ws/src \
  && git clone https://github.com/osrf/vrx.git \
- && git clone -b fix_log_playback https://github.com/osrf/vorc.git
+ && git clone https://github.com/osrf/vorc.git
 
 # Compile VRX and VORC
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vorc_ws && colcon build"
@@ -136,8 +137,6 @@ ENV LANG en_US.UTF-8
 #  && mkdir -p $HOME/.gazebo/models \
 #  && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
 #  && rm /tmp/default.tar.gz
-
-RUN sudo apt-get install -y psmisc
 
 # setup entrypoint
 COPY ./vorc_entrypoint.sh /

--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir -p vorc_ws/src
 RUN /bin/sh -c 'echo "Cloning git repos..."'
 RUN cd /home/$USER/vorc_ws/src \
  && git clone https://github.com/osrf/vrx.git \
- && git clone https://github.com/osrf/vorc.git
+ && git clone -b fix_log_playback https://github.com/osrf/vorc.git
 
 # Compile VRX and VORC
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vorc_ws && colcon build"
@@ -137,8 +137,12 @@ ENV LANG en_US.UTF-8
 #  && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
 #  && rm /tmp/default.tar.gz
 
+#RUN sudo apt-get install -y psmisc
+
 # setup entrypoint
 COPY ./vorc_entrypoint.sh /
 COPY ./run_vorc_trial.sh /
+COPY ./play_vorc_log.sh /
+COPY ./gz_utils.sh /
 
 ENTRYPOINT ["/vorc_entrypoint.sh"]

--- a/vorc_server/vorc-server/gz_utils.sh
+++ b/vorc_server/vorc-server/gz_utils.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-is_gzserver_running()
+# gz_utils.sh: Utility functions used for running and playing back trials.
+
+function is_gzserver_running()
 {
-  if pgrep gzserver >/dev/null; then
+  if pgrep gzserver > /dev/null; then
     true
   else
     false
   fi
 }
 
-wait_until_gzserver_is_down()
+# Check if gzclient is running
+function is_gzclient_running()
+{
+  if pgrep gzclient > /dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+function wait_until_gzserver_is_down()
 {
   until ! is_gzserver_running
   do
@@ -17,8 +29,7 @@ wait_until_gzserver_is_down()
   done
 }
 
-
-wait_until_gzserver_is_up()
+function wait_until_gzserver_is_up()
 {
   until is_gzserver_running
   do

--- a/vorc_server/vorc-server/gz_utils.sh
+++ b/vorc_server/vorc-server/gz_utils.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+is_gzserver_running()
+{
+  if pgrep gzserver >/dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+wait_until_gzserver_is_down()
+{
+  until ! is_gzserver_running
+  do
+    sleep 1
+  done
+}
+
+
+wait_until_gzserver_is_up()
+{
+  until is_gzserver_running
+  do
+    sleep 1
+  done
+}

--- a/vorc_server/vorc-server/play_vorc_log.sh
+++ b/vorc_server/vorc-server/play_vorc_log.sh
@@ -93,21 +93,15 @@ is_gzclient_running()
 # tells us that the playback has been paused. This event will trigger the end of the recording.
 wait_until_playback_ends()
 {
-  echo "0000000000000"
   echo -n "Waiting for playback to end..."
-  echo "111111111111111"
   gz_world_stats_topic=$(gz topic -l | grep "world_stats")
-  echo "222222222222222"
-  echo [${gz_world_stats_topic}]
+  echo "[${gz_world_stats_topic}]"
 
-  until gz topic -e ${gz_world_stats_topic} -d 1 -u | grep "paused: true" \
+  until gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: true" \
     > /dev/null
   do
-    echo "333333333333333"
     sleep 1
-    echo "444444444444444"
     if ! is_gzclient_running ; then
-      echo "55555555555555555"
       echo 1>&2 "GZ client not running, bailing"
       return 0
     fi

--- a/vorc_server/vorc-server/play_vorc_log.sh
+++ b/vorc_server/vorc-server/play_vorc_log.sh
@@ -86,9 +86,15 @@ wait_for_unpause_signal()
   # Source ROS
   source $HOME/vorc_ws/install/setup.bash
 
-  # Wait for Docker injection from host to tell us it is ready to record screen
-  until rostopic echo /record_ready -n 1 | grep "data: True" &> /dev/null
+  # Wait for Docker injection from host to tell us it is ready
+  #until rostopic echo /host_ready -n 1 | grep "data: True" &> /dev/null
+  #do
+  #  echo `rostopic echo /host_ready -n 1 | grep "data: True"`
+  # TODO(mabelzhang): This is never set! Maybe need to set ROS_MASTER_URI
+  # in the injection??
+  until rosparam get /host_ready | grep "true" &> /dev/null
   do
+    echo `rosparam get /host_ready`
     sleep 1
   done
   echo -e "${GREEN}OK${NOCOLOR}"

--- a/vorc_server/vorc-server/play_vorc_log.sh
+++ b/vorc_server/vorc-server/play_vorc_log.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# play_vorc_log.sh: A shell script to play back Gazebo log file from a VORC
+# trial.
+
+# Get directory of this file
+#DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+#source ${DIR}/gz_utils.sh
+
+is_gzserver_running()
+{
+  if pgrep gzserver >/dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+wait_until_gzserver_is_down()
+{
+  until ! is_gzserver_running
+  do
+    sleep 1
+  done
+}
+
+wait_until_gzserver_is_up()
+{
+  until is_gzserver_running
+  do
+    sleep 1
+  done
+}
+
+# Constants.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
+
+# Define usage function.
+usage()
+{
+  echo "Usage: $0 <log_file> <destination_file>"
+  exit 1
+}
+
+# Call usage() function if arguments not supplied.
+[[ $# -ne 2 ]] && usage
+
+LOG_FILE=$1
+OUTPUT=$2
+
+# Create a directory for the Gazebo log and the score file.
+DESTINATION_FOLDER="$(dirname "$OUTPUT")"
+if [ -d "$DESTINATION_FOLDER" ]; then
+  echo -e "${YELLOW}Wrn: Destination folder already exists. Data might be"\
+          "overwritten${NOCOLOR}\n"
+fi
+mkdir -p $DESTINATION_FOLDER
+
+echo "Starting Gazebo..."
+echo "Check any possible errors after the run in $OUTPUT.playback_output.txt..."
+
+# Start Gazebo in playback mode
+roslaunch vorc_gazebo playback.launch gui:=true log_file:=$LOG_FILE paused:=true verbose:=true \
+  > $OUTPUT.playback_output.txt 2>&1 &
+roslaunch_pid=$!
+wait_until_gzserver_is_up
+echo -e "${GREEN}OK${NOCOLOR}\n"
+
+# Check if the log file has errors, likely forgot to source ws
+if grep -Fq "RLException" $OUTPUT.playback_output.txt
+then
+  echo "Failed to find playback launch file. Did you source your vorc_ws?"
+  exit 1
+fi
+
+echo "Playing back log file..."
+
+# Check if gzclient is running
+is_gzclient_running()
+{
+  if pgrep gzclient >/dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+# Wait until the gazebo world stats topic (eg. /gazebo/<world>/world_stats)
+# tells us that the playback has been paused. This event will trigger the end of the recording.
+wait_until_playback_ends()
+{
+  echo "0000000000000"
+  echo -n "Waiting for playback to end..."
+  echo "111111111111111"
+  gz_world_stats_topic=$(gz topic -l | grep "world_stats")
+  echo "222222222222222"
+  echo [${gz_world_stats_topic}]
+
+  until gz topic -e ${gz_world_stats_topic} -d 1 -u | grep "paused: true" \
+    > /dev/null
+  do
+    echo "333333333333333"
+    sleep 1
+    echo "444444444444444"
+    if ! is_gzclient_running ; then
+      echo "55555555555555555"
+      echo 1>&2 "GZ client not running, bailing"
+      return 0
+    fi
+  done
+  echo -e "${GREEN}OK${NOCOLOR}"
+}
+
+wait_until_playback_ends
+
+echo -n "Terminating Gazebo..."
+killall -w gzserver gzclient
+wait_until_gzserver_is_down
+echo -e "${GREEN}OK${NOCOLOR}\n"
+
+# Kill rosnodes
+echo "Killing rosnodes"
+rosnode kill --all
+sleep 1s
+echo -e "${GREEN}OK${NOCOLOR}\n"
+
+# Kill roslaunch
+echo "Killing roslaunch pid: ${roslaunch_pid}"
+kill -INT ${roslaunch_pid}
+echo -e "${GREEN}OK${NOCOLOR}\n"

--- a/vorc_server/vorc-server/run_vorc_trial.sh
+++ b/vorc_server/vorc-server/run_vorc_trial.sh
@@ -2,31 +2,10 @@
 
 # run_vorc_trial.sh: A shell script to execute one vorc trial.
 
-is_gzserver_running()
-{
-  if pgrep gzserver >/dev/null; then
-    true
-  else
-    false
-  fi
-}
+# Get directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-wait_until_gzserver_is_down()
-{
-  until ! is_gzserver_running
-  do
-    sleep 1
-  done
-}
-
-
-wait_until_gzserver_is_up()
-{
-  until is_gzserver_running
-  do
-    sleep 1
-  done
-}
+source ${DIR}/gz_utils.sh
 
 set -e
 
@@ -69,7 +48,7 @@ echo "Starting vorc trial..."
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
 # To watch the actual competition run, set gui:=true.
-roslaunch vorc_gazebo marina.launch gui:=false world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > $HOME/verbose_output.txt 2>&1 &
+roslaunch vorc_gazebo marina.launch gui:=true world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > $HOME/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"

--- a/vorc_server/vorc-server/run_vorc_trial.sh
+++ b/vorc_server/vorc-server/run_vorc_trial.sh
@@ -48,7 +48,7 @@ echo "Starting vorc trial..."
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
 # To watch the actual competition run, set gui:=true.
-roslaunch vorc_gazebo marina.launch gui:=true world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > $HOME/verbose_output.txt 2>&1 &
+roslaunch vorc_gazebo marina.launch gui:=false world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > $HOME/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"


### PR DESCRIPTION
Addresses Infrastructure bullet 1 in https://github.com/osrf/vrx-docker/issues/20.

I completely rewrote the script for trial playback and video recording, so that the trial recording `state.log` is now played back from within the server Docker container, instead of on the host machine.

This was necessary, because during evaluation rehearsal, we found that when the log was being played back on the host machine, we had to do a hack of replicating the Docker container's `/vorc_ws/install/cora_description` directory structure on the host machine, in order for the robot to show up in Gazebo. Other environment configurations were probably also different between host and the server container depending on the evaluator.

Both the playback and video recording work quite well for me now. There were some kinks two days ago, but I've fixed all of them. Everything is autopilot.

I'm really happy about this fix. Hope this works for other people too.

To test:

Preliminaries:
```
# Rebuild Docker image
./vorc_server/build_image.bash -n
# Prepare teams and tasks
./multi_scripts/prepare_all_teams.bash 
./multi_scripts/prepare_all_task_trials.bash
# Run some task of your choice
./run_trial.bash -n ghostship wayfinding 0
```

Test playing back log file:
```
./replay_trial.bash -n ghostship wayfinding 0
```

Test playing back log file and generate screen recording (this calls `replay_trial.bash` internally):
```
./generate_trial_video.bash -n ghostship wayfinding 0
```