### PR TITLE
Adding compressed image topics

### DIFF
--- a/vorc_server/vorc-server/Dockerfile
+++ b/vorc_server/vorc-server/Dockerfile
@@ -56,6 +56,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     libgles2-mesa-dev \
     ${GAZ} \
     lib${GAZ}-dev \
+    ros-${DIST}-compressed-image-transport \
     ros-${DIST}-ros-base \
     ros-${DIST}-xacro \
     ros-${DIST}-gazebo-ros \


### PR DESCRIPTION
We need to install the ROS compressed-image-transport package in the Docker server, otherwise the `compressed` image topics will not be available. See discussion in https://github.com/osrf/vorc-events/pull/21 . 