### PR TITLE
Generate acoustic pinger YAML for gymkhana

### DIFF
--- a/prepare_task_trials.bash
+++ b/prepare_task_trials.bash
@@ -2,7 +2,7 @@
 
 # prepare_task_trials.bash: A bash script to generate single tasks's world files, one for each task.
 #
-# E.g.: ./prepare_task_trials.bash station_keeping
+# E.g.: ./prepare_task_trials.bash stationkeeping
 
 set -e
 
@@ -46,8 +46,15 @@ world_target=${DIR}/generated/task_generated/${TASK_NAME}/worlds/
 mkdir -p ${world_xacro_target}
 mkdir -p ${world_target}
 
+extra_gen_args=""
+if [ "${TASK_NAME}" = "gymkhana" ]; then
+  config_target=${DIR}/generated/task_generated/${TASK_NAME}/config/
+  mkdir -p ${config_target}
+  extra_gen_args="config_target:=${config_target}"
+fi
+
 # Generate worlds
 echo "Generating worlds..."
-roslaunch vrx_gazebo generate_worlds.launch requested:=$TASK_CONFIG world_xacro_target:=$world_xacro_target world_target:=$world_target competition_pkg:="vorc_gazebo" world_name:="vorc_example_course"
+roslaunch vrx_gazebo generate_worlds.launch requested:=$TASK_CONFIG world_xacro_target:=$world_xacro_target world_target:=$world_target competition_pkg:="vorc_gazebo" world_name:="vorc_example_course" ${extra_gen_args}
 echo -e "${GREEN}OK${NOCOLOR}\n"
 echo -e "${GREEN}If successful, worlds are generated in \n  $world_xacro_target and \n  $world_target${NOCOLOR}\n"

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -105,6 +105,12 @@ else
   echo -e "${RED}Err: ${COMP_GENERATED_DIR}/${WORLD_FILE_SUFFIX} not found."; exit 1;
 fi
 
+EXTRA_LAUNCH_ARGS=""
+if [ "${TASK_NAME}" = "gymkhana" ]; then
+  CONFIG_FILE_SUFFIX=config/${TASK_NAME}${TRIAL_NUM}.yaml
+  EXTRA_LAUNCH_ARGS="pinger_params:=/task_generated/${CONFIG_FILE_SUFFIX}"
+fi
+
 # Ensure any previous containers are killed and removed.
 ${DIR}/utils/kill_vorc_containers.bash
 
@@ -135,7 +141,7 @@ echo "---------------------------------"
 # container waiting for ROS master and has error before server is created.
 # Run Gazebo simulation server container
 WORLD_FILE=/task_generated/${WORLD_FILE_SUFFIX}
-SERVER_CMD="/run_vorc_trial.sh ${WORLD_FILE} ${LOG_DIR}"
+SERVER_CMD="/run_vorc_trial.sh ${TASK_NAME} ${WORLD_FILE} ${LOG_DIR} ${EXTRA_LAUNCH_ARGS}"
 SERVER_IMG="vorc-server-${ROS_DISTRO}${image_nvidia}:latest"
 ${DIR}/vorc_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERVER_IMG \
   "--net ${NETWORK} \

--- a/task_config/gymkhana.yaml
+++ b/task_config/gymkhana.yaml
@@ -3,6 +3,8 @@ constant:
     macros:
         marina_minus_scene:
             -
+    yamls:
+
     sequence:
 
 tasks:
@@ -16,6 +18,16 @@ tasks:
             -
         gymkhana:
             -
+
+    # For Gymkhana, also specify pinger positions here to generate yaml files
+    # NOTE:
+    # Position must be the same as pinger_x, pinger_y, pinger_z in the sequence
+    # block below, otherwise behavior will be undefined. This is not enforced
+    # in code and must be manually checked for now.
+    yamls:
+        0:
+            position_1: [116, -278, -5]
+
     sequence:
         0:
             ocean_waves:

--- a/task_config/wayfinding.yaml
+++ b/task_config/wayfinding.yaml
@@ -14,7 +14,7 @@ environment:
             -
         scene_macro:
             -
-        stationkeeping:
+        wayfinding:
             -
     sequence:
         0:


### PR DESCRIPTION
Depends on https://github.com/osrf/vrx/pull/234 and https://github.com/osrf/vorc/pull/39

The script now launches the task-specific launch file, as opposed to everything using `marina.launch`. This is to make sure we're using the latest changes in the osrf/vorc repo for each task, as opposed to coupling `marina.launch` or even a new competition-specific launch file to vrx-docker and parsing competition-specific args.
Hopefully this means vrx-docker behavior is one step closer to regular vorc repo behavior with changes in the future.
This part of the PR will probably need backporting to vrx in `master` branch.

To test gymkhana acoustic pinger:

Change this line in `vorc_server/vorc-server/Dockerfile` to clone the new feature branch:
```
 && git clone -b fix_gymkhana_eval_pinger https://github.com/osrf/vorc.git
```

Rebuild Dockerfile:
```
./vorc_server/build_image.bash -n
```

Change these lines in `task_config/gymkhana.yaml` to get a non-default pinger position.
These lines must have the same values. Unfortunately, this needs to be manually enforced right now. See explanation in osrf/vrx#234.
```
            position_1: [1, 2, 3]
...
                  pinger_x: 1
                  pinger_y: 2
                  pinger_z: 3
```

Make sure all the tasks still get generated correctly, diff with generated files before this PR:
```
mv generated generated_bak
./prepare_task_trials.bash wayfinding
./prepare_task_trials.bash gymkhana
./prepare_task_trials.bash stationkeeping
./prepare_task_trials.bash perception

# Generated by osrf/vrx#234
# Gymkhana YAML files should be generated, formatting may be different
# but values should be same as position_1 in task_config/gymkhana.yaml
cat generated/task_generated/gymkhana/config/gymkhana0.yaml

# All world files should be unchanged
diff generated/task_generated/wayfinding/worlds/ generated_bak/task_generated/wayfinding/worlds/
diff generated/task_generated/perception/worlds/ generated_bak/task_generated/perception/worlds/
diff generated/task_generated/stationkeeping/worlds/ generated_bak/task_generated/stationkeeping/worlds/
diff generated/task_generated/gymkhana/worlds/ generated_bak/task_generated/gymkhana/worlds/
```

Check acoustic pinger behavior (this is the key fix of this PR):
```
$ ./run_trial.bash -n ghostship gymkhana 0
$ docker exec -it vorc-server-system bash

# Set by the launch file in osrf/vorc#39
$ rosparam get /set_pinger_position/position_1
[1, 2, 3]

# vorc_gazebo/nodes/set_pinger_position.py is publishing the custom pinger
$ rostopic echo /cora/sensors/pingers/pinger/set_pinger_position
x: 1.0
y: 2.0
z: 3.0
```

Make sure other tasks still run, since the launch file is task-specific now:
```
./run_trial.bash -n ghostship wayfinding 0
./run_trial.bash -n ghostship stationkeeping 0
./run_trial.bash -n ghostship perception 0
```