### PR TITLE
Enable NVIDIA runtime for competitor container

### DIFF
--- a/run_trial.bash
+++ b/run_trial.bash
@@ -24,6 +24,7 @@ usage()
 }
 
 # Parse arguments
+RUNTIME="runc"
 nvidia_arg=""
 image_nvidia=""
 
@@ -34,6 +35,7 @@ do
 
   case $key in
       -n|--nvidia)
+      RUNTIME="nvidia"
       nvidia_arg="-n"
       image_nvidia="-nvidia"
       shift
@@ -170,6 +172,8 @@ docker run \
     --env ROS_MASTER_URI=${ROS_MASTER_URI} \
     --env ROS_IP=${COMPETITOR_ROS_IP} \
     --ip ${COMPETITOR_ROS_IP} \
+    --privileged \
+    --runtime=$RUNTIME \
     ${DOCKERHUB_IMAGE} &
 
 # Run competition until server is ended


### PR DESCRIPTION
Draft until I can run a solution that uses CUDA.

Add `--runtime=nvidia` and `--privileged` for the *competitor* container.

We already had these two flags for the server container, but not the competitor container.
If the competitor uses NVIDIA CUDA-capable GPU, then the nvidia runtime flag is required.

Without `--runtime=nvidia`:
```
$ docker exec -it vorc-competitor-system bash
$ nvidia-smi
bash: nvidia-smi: command not found
```

With `--runtime=nvidia`, note I get the `CUDA Version: 11.0` line inside the Docker container:
```
$ docker exec -it vorc-competitor-system bash
$ nvidia-smi
Thu Dec 17 01:48:45 2020       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 455.45.01    Driver Version: 455.45.01    CUDA Version: 11.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  GeForce GTX 105...  On   | 00000000:01:00.0 Off |                  N/A |
| N/A   73C    P0    N/A /  N/A |   1875MiB /  4042MiB |     74%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+
```

On my host, I actually have CUDA Version 11.1. I don't know if that makes a difference.

Without `--privileged`:
```
$ docker exec -it vorc-competitor-system bash
$ ls /dev/nvidia*
/dev/nvidia0  /dev/nvidiactl
```

With `--privileged`, the `ls` result matches my host machine exactly:
```
$ docker exec -it vorc-competitor-system bash
$ ls /dev/nvidia* -1
/dev/nvidia-modeset
/dev/nvidia-uvm
/dev/nvidia-uvm-tools
/dev/nvidia0
/dev/nvidiactl

/dev/nvidia-caps:
nvidia-cap1
nvidia-cap2
```