### PR TITLE
Backport #26, #28, #30 from VORC to VRX

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,20 +320,46 @@ cat generated/logs/example_team/stationkeeping/0/trial_score.txt
 
 ## Quick Start Instructions For a Single Trial: Trial videos and playback
 
-### Generating a single trial video
+### Playing back the recorded log of a single trial
 
 After running a trial, a `state.log` file is stored under `generated/logs/<team>/<task>/<trial_num>/gazebo-server`. This is a playback log file that allows you to play back the trial. 
-To generate a trial video, please run the trial using the steps above, source vrx, and then run
+
+To play back the trial with Gazebo GUI from within the competition Docker container, run
 
 ```
-./generate_trial_video.bash example_team stationkeeping 0
+./replay_trial.bash -n example_team stationkeeping 0
+```
+
+By default, this is on autopilot and will shut down Gazebo after log playback is finished.
+A side effect is that it will shut down if the playback is paused (which happens to be an indication of the log playback having finished).
+
+To inspect more carefully, you may wish to pause playback without Gazebo shutting down.
+That can be done by issuing `--keep-gz` on the command line:
+```
+./replay_trial.bash -n --keep-gz example_team wayfinding 0
+```
+
+When you are done with manual inspection, you can shut down Gazebo cleanly by issuing this to the container:
+```
+docker exec -it vrx-server-system killall -w gzclient gzserver
+```
+The autopilot will detect Gazebo termination and shut down the rest of the container.
+
+`replay_trial.bash` accepts a few options for more manual inspections, which you can view in the usage by running it alone without arguments.
+
+### Generating a single trial video
+
+To make a screen recording of the trial while playing back, run the following command. Internally, this calls `replay_trial.bash` above.
+
+```
+./generate_trial_video.bash -n example_team stationkeeping 0
 
 # For your team you will run:
-# ./generate_trial_video.bash <your_team_name> <task_name> <trial_number>
+# ./generate_trial_video.bash -n <your_team_name> <task_name> <trial_number>
 ```
 
 This will start the Gazebo trial playback, begin screen capture on the Gazebo window, and then store the video file, record output and playback output in `generated/logs/<team>/<task>/<trial_num>/video`. 
-Please note that you must close other tabs related to Gazebo for this to work properly, as it puts the Gazebo window at the front (not background). If you have a browser tab open related to Gazebo,
+Please note that you must close other tabs related to Gazebo for this to work properly, as it puts the Gazebo window at the front (not background). Keep the Gazebo window on top. If you have a browser tab open related to Gazebo,
 it may find that window, instead of the actual Gazebo simulation window.
 
 There should be a new directory called `generated/logs/<team>/<task>/<trial_num>/video` that contains the following:

--- a/generate_trial_video.bash
+++ b/generate_trial_video.bash
@@ -66,7 +66,7 @@ echo "Waiting for Docker container to terminate..."
 wait $SERVER_PID
 echo -e "${GREEN}OK${NOCOLOR}"
 
-echo "Encoding video and storing in $OUTPUT before terminating Gazebo..."
+echo "Encoding video and storing in $HOST_OUTPUT before terminating Gazebo..."
 killall -w recordmydesktop
 echo -e "${GREEN}OK${NOCOLOR}"
 

--- a/generate_trial_video.bash
+++ b/generate_trial_video.bash
@@ -1,125 +1,28 @@
 #!/bin/bash
 
-# generate_trial_video.bash: A bash script to generate a video from a Gazebo playback log file.
+# generate_trial_video.bash: A bash script to generate a video from a Gazebo
+# playback log file.
 #
-# E.g.: ./generate_trial_video.bash example_team station_keeping 0
+# Input: Gazebo log file state.log
+# Output: Recorded video in .ogv
 #
-# Please, install the following dependencies before using the script:
+# Usage:
+# ./generate_trial_video.bash -n example_team station_keeping 0
+#
+# Please install the following dependencies before using the script:
 #   sudo apt-get install recordmydesktop wmctrl psmisc
-
-# Exit on error
-set -e
-
-# Constants
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-NOCOLOR='\033[0m'
-
-# Define usage function.
-usage()
-{
-  echo "Usage: $0 <team_name> <task_name> <trial_num>"
-  exit 1
-}
-
-# Check if gzclient is running
-is_gzclient_running()
-{
-  if pgrep gzclient >/dev/null; then
-    true
-  else
-    false
-  fi
-}
-
-# Wait until the gazebo world stats topic (eg. /gazebo/robotx_example_course/world_stats /gazebo/<world>/world_stats)
-# tells us that the playback has been paused. This event will trigger the end of the recording.
-wait_until_playback_ends()
-{
-  echo -n "Waiting for playback to end..."
-  gz_world_stats_topic=$(gz topic -l | grep "world_stats")
-
-  until gz topic -e $gz_world_stats_topic -d 1 -u | grep "paused: true" \
-    > /dev/null
-  do
-    sleep 1
-    if ! is_gzclient_running ; then
-      echo 1>&2 "GZ client not running, bailing"
-      return 0
-    fi
-  done
-  echo -e "${GREEN}OK${NOCOLOR}"
-}
-
-# Call usage() function if arguments not supplied.
-[[ $# -ne 3 ]] && usage
-
-TEAM_NAME=$1
-TASK_NAME=$2
-TRIAL_NUM=$3
 
 # Get directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-GZ_LOG_FILE=$DIR/generated/logs/$TEAM_NAME/$TASK_NAME/$TRIAL_NUM/gazebo-server/state.log
+# Play back the log file.
+# Specify --keep-docker so that it doesn't block for container to terminate and
+# clean up processes, as we will do that later in this script.
+# Specify --manual-play to start playback from this script after screen
+# recording is ready to begin.
+source ${DIR}/replay_trial.bash --keep-docker --manual-play "$@"
 
-# Output directory
-OUTPUT_DIR=$DIR/generated/logs/$TEAM_NAME/$TASK_NAME/$TRIAL_NUM/video
-if [ -d "$OUTPUT_DIR" ]; then
-  echo "Overwriting directory: ${OUTPUT_DIR}"
-  rm -R $OUTPUT_DIR
-else
-  echo "Creating directory: ${OUTPUT_DIR}"
-fi
-
-mkdir -p $OUTPUT_DIR
-OUTPUT=$OUTPUT_DIR/playback_video.ogv
-
-# Sanity check: Make sure that the log file exists.
-if [ ! -f $GZ_LOG_FILE ]; then
-    echo "Gazebo log file [$GZ_LOG_FILE] not found!"
-    exit 1
-else
-    echo "Found Gazebo log file [$GZ_LOG_FILE]"
-fi
-
-# Sanity check: Make sure that catkin_find is found.
-which catkin_find > /dev/null || { echo "Unable to find catkin_find."\
-  "Did you source your ROS setup.bash file?" ; exit 1; }
-
-# Sanity check: Kill any dangling Gazebo before moving forward.
-killall -wq gzserver gzclient || true
-
-echo "Sanity checks complete"
-
-# Define constants for recording
-x=100
-y=100
-width=1000
-height=750
-BLACK_WINDOW_TIME=2
-
-# Tell gazebo client what size and place it should be
-echo "[geometry]
-width=$width
-height=$height
-x=$x
-y=$y" > ~/.gazebo/gui.ini
-
-# Start Gazebo in playback mode
-roslaunch vrx_gazebo playback.launch log_file:=$GZ_LOG_FILE paused:=true verbose:=true \
-  > $OUTPUT.playback_output.txt 2>&1 &
-sleep 1s
-
-# Check if the log file has errors, likely forgot to source ws
-if grep -Fq "RLException" $OUTPUT.playback_output.txt
-then
-  echo "Failed to find playback launch file. Did you source your vrx_ws?"
-  exit 1
-fi
-
-echo "Setting up for playback..."
+echo "Setting up screen recording..."
 
 # Wait and find the Gazebo Window ID.
 # Note: May find Gazebo in browser tab, which is wrong. Please close all Gazebo related tabs.
@@ -132,7 +35,6 @@ GAZEBO_WINDOW_ID=`wmctrl -lp | grep Gazebo | cut -d" " -f 1`
 if [ -z "$GAZEBO_WINDOW_ID" ]; then
   echo "Gazebo window not detected. Exiting..."
   sleep 2
-  killall -w gzserver gzclient
   exit 1
 fi
 
@@ -143,21 +45,35 @@ wmctrl -i -a ${GAZEBO_WINDOW_ID}
 # screen for a long time.
 sleep $BLACK_WINDOW_TIME
 
-# Unpause the simulation.
-echo -n "Playing back..."
-gz world -p 0
-echo -e "${GREEN}OK${NOCOLOR}"
-
 # Start recording the Gazebo Window.
-echo -n "Recording..."
-recordmydesktop --fps=30 --windowid=${GAZEBO_WINDOW_ID} --no-sound -o $OUTPUT \
-  > $OUTPUT.record_output.txt 2>&1 &
+echo "Recording screen on host..."
+recordmydesktop --fps=30 --windowid=${GAZEBO_WINDOW_ID} --no-sound -o $HOST_OUTPUT \
+  > $HOST_OUTPUT.record_output.txt 2>&1 &
 echo -e "${GREEN}OK${NOCOLOR}"
 
-# Wait until the playback ends.
-wait_until_playback_ends
+# Give Gazebo time to finish starting up
+sleep 3s
 
-# Terminate Gazebo.
-echo -n "Encoding video and storing in $OUTPUT ..."
-killall -w gzserver gzclient recordmydesktop
+# Unpause the simulation to begin playback
+echo "Injecting signal into Docker container to unpause Gazebo..."
+# Inject unpause command into Docker container
+UNPAUSE_CMD="gz world -p 0"
+docker exec -it ${SERVER_CONTAINER_NAME} ${UNPAUSE_CMD}
 echo -e "${GREEN}OK${NOCOLOR}"
+
+# Wait for Docker container to terminate
+echo "Waiting for Docker container to terminate..."
+wait $SERVER_PID
+echo -e "${GREEN}OK${NOCOLOR}"
+
+echo "Encoding video and storing in $OUTPUT before terminating Gazebo..."
+killall -w recordmydesktop
+echo -e "${GREEN}OK${NOCOLOR}"
+
+echo "Playback ended"
+echo "---------------------------------"
+
+# Kill and remove all containers before exit
+${DIR}/utils/kill_vrx_containers.bash
+
+exit 0

--- a/replay_trial.bash
+++ b/replay_trial.bash
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+# replay_trial.bash: Replay a trial recorded to a Gazebo log file, e.g.
+# state.log.
+#
+# Input: Gazebo log file state.log
+#
+# Usage:
+# ./replay_trial.bash -n example_team station_keeping 0
+
+# Exit on error
+set -e
+
+# Constants
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
+
+# Define usage function.
+usage()
+{
+  echo "Usage: $0 [-n --nvidia] [--keep-docker] [--manual-play] [--keep-gz] <team_name> <task_name> <trial_num>"
+  echo "--keep-docker: Keep Gazebo window open and Docker container running after playback ends."
+  echo "  By default, everything is terminated automatically."
+  echo "--manual-play: Do not automatically start playback. Wait for user to click in GUI."
+  echo "  By default, playack automatically starts."
+  echo "--keep-gz: Keep Gazebo server and client running after playback ends."
+  echo "  Implies --keep-docker. By default, they are shut down automatically."
+  exit 1
+}
+
+# Parse arguments
+nvidia_arg=""
+image_nvidia=""
+keep_docker=1
+
+# Args to pass to script internal to Docker container
+manual_play=""
+keep_gz=""
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+
+  case $key in
+    -n|--nvidia)
+      nvidia_arg="-n"
+      image_nvidia="-nvidia"
+      shift
+      ;;
+
+    --keep-docker)
+      keep_docker=1
+      shift
+      ;;
+
+    --manual-play)
+      manual_play="--manual-play"
+      shift
+      ;;
+
+    --keep-gz)
+      keep_docker=1
+      keep_gz="--keep-gz"
+      shift
+      ;;
+
+    # Treat unknown options as positional args
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL[@]}"
+
+# Call usage() function if arguments not supplied.
+[[ $# -ne 3 ]] && echo "Invalid arguments: $@" && usage
+
+TEAM_NAME=$1
+TASK_NAME=$2
+TRIAL_NUM=$3
+
+# Constants for containers
+SERVER_CONTAINER_NAME=vrx-server-system
+ROS_DISTRO=melodic
+LOG_DIR=/vrx/logs
+NETWORK=vrx-network
+NETWORK_SUBNET="172.16.0.10/16" # subnet mask allows communication between IP addresses with 172.16.xx.xx (xx = any)
+SERVER_ROS_IP="172.16.0.22"
+COMPETITOR_ROS_IP="172.16.0.20"
+ROS_MASTER_URI="http://${SERVER_ROS_IP}:11311"
+
+# Get directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Create the network for the containers to talk to each other.
+${DIR}/utils/vrx_network.bash "${NETWORK}" "${NETWORK_SUBNET}"
+
+echo "Playing back $TEAM_NAME solution in $TASK_NAME $TRIAL_NUM"
+echo -e "=================================\n"
+
+echo "Setting up"
+echo "---------------------------------"
+
+# Input file
+HOST_LOG_DIR=${DIR}/generated/logs/${TEAM_NAME}/${TASK_NAME}/${TRIAL_NUM}
+LOG_SUFFIX=/gazebo-server/state.log
+LOG_FILE=${LOG_DIR}${LOG_SUFFIX}
+HOST_LOG_FILE=${HOST_LOG_DIR}${LOG_SUFFIX}
+# Sanity check: Make sure that the log file exists.
+if [ ! -f $HOST_LOG_FILE ]; then
+  echo "Gazebo log file [$HOST_LOG_FILE] not found!"
+  exit 1
+else
+  echo "Found Gazebo log file [$HOST_LOG_FILE]"
+fi
+
+# Output directory
+HOST_OUTPUT_DIR=${HOST_LOG_DIR}/video
+OUTPUT_DIR=${LOG_DIR}/video
+if [ -d "$HOST_OUTPUT_DIR" ]; then
+  echo "Overwriting directory: ${HOST_OUTPUT_DIR}"
+  rm -R $HOST_OUTPUT_DIR
+else
+  echo "Creating directory: ${HOST_OUTPUT_DIR}"
+fi
+
+mkdir -p $HOST_OUTPUT_DIR
+OUTPUT_SUFFIX=/playback_video.ogv
+HOST_OUTPUT=$HOST_OUTPUT_DIR$OUTPUT_SUFFIX
+OUTPUT=$OUTPUT_DIR$OUTPUT_SUFFIX
+
+# Ensure any previous containers are killed and removed.
+${DIR}/utils/kill_vrx_containers.bash
+
+echo "Starting simulation server container for playback"
+echo "-------------------------------------------------"
+
+# Define constants for recording
+x=100
+y=100
+width=1000
+height=750
+BLACK_WINDOW_TIME=2
+
+HOST_GZ_GUI_CONFIG_DIR=${DIR}/generated/logs/playback_gazebo
+GZ_GUI_CONFIG_DIR=/home/$USER/.gazebo
+if [ -d "$HOST_GZ_GUI_CONFIG_DIR" ]; then
+  echo "Overwriting directory: ${HOST_GZ_GUI_CONFIG_DIR}"
+  rm -R $HOST_GZ_GUI_CONFIG_DIR
+else
+  echo "Creating directory: ${HOST_GZ_GUI_CONFIG_DIR}"
+fi
+mkdir -p $HOST_GZ_GUI_CONFIG_DIR
+
+# Tell gazebo client what size and place it should be
+echo "[geometry]
+width=$width
+height=$height
+x=$x
+y=$y" > ${HOST_GZ_GUI_CONFIG_DIR}/gui.ini
+
+# Run Gazebo simulation server container
+SERVER_CMD="/play_vrx_log.sh ${LOG_FILE} ${OUTPUT} ${manual_play} ${keep_gz}"
+SERVER_IMG="vrx-server-${ROS_DISTRO}${image_nvidia}:latest"
+${DIR}/vrx_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERVER_IMG \
+  "--net ${NETWORK} \
+  --ip ${SERVER_ROS_IP} \
+  -v ${HOST_LOG_DIR}:${LOG_DIR} \
+  -v ${HOST_OUTPUT_DIR}:${OUTPUT_DIR} \
+  -v ${HOST_GZ_GUI_CONFIG_DIR}:${GZ_GUI_CONFIG_DIR} \
+  -e ROS_MASTER_URI=${ROS_MASTER_URI} \
+  -e ROS_IP=${SERVER_ROS_IP} \
+  -e VRX_DEBUG=false" \
+  "${SERVER_CMD}" &
+SERVER_PID=$!
+
+if [ $keep_docker -eq 0 ]; then
+  # Wait for Docker container to terminate
+  wait $SERVER_PID
+
+  echo "Playback ended"
+  echo "---------------------------------"
+
+  # Kill and remove all containers before exit
+  ${DIR}/utils/kill_vrx_containers.bash
+
+  exit 0
+fi

--- a/replay_trial.bash
+++ b/replay_trial.bash
@@ -86,7 +86,7 @@ TRIAL_NUM=$3
 
 # Constants for containers
 SERVER_CONTAINER_NAME=vrx-server-system
-ROS_DISTRO=melodic
+ROS_DISTRO=noetic
 LOG_DIR=/vrx/logs
 NETWORK=vrx-network
 NETWORK_SUBNET="172.16.0.10/16" # subnet mask allows communication between IP addresses with 172.16.xx.xx (xx = any)

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -24,6 +24,7 @@ usage()
 }
 
 # Parse arguments
+RUNTIME="runc"
 nvidia_arg=""
 image_nvidia=""
 
@@ -34,6 +35,7 @@ do
 
   case $key in
       -n|--nvidia)
+      RUNTIME="nvidia"
       nvidia_arg="-n"
       image_nvidia="-nvidia"
       shift
@@ -171,6 +173,8 @@ docker run \
     --env ROS_MASTER_URI=${ROS_MASTER_URI} \
     --env ROS_IP=${COMPETITOR_ROS_IP} \
     --ip ${COMPETITOR_ROS_IP} \
+    --privileged \
+    --runtime=$RUNTIME \
     ${DOCKERHUB_IMAGE} &
 
 # Run competition until server is ended

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -31,6 +31,7 @@ ARG GAZ=gazebo9
          libeigen3-dev \
          pkg-config \
          language-pack-en \
+         psmisc \
   && apt clean
 
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -139,5 +140,7 @@ ENV LANG en_US.UTF-8
 # setup entrypoint
 COPY ./vrx_entrypoint.sh /
 COPY ./run_vrx_trial.sh /
+COPY ./play_vrx_log.sh /
+COPY ./gz_utils.sh /
 
 ENTRYPOINT ["/vrx_entrypoint.sh"]

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -55,6 +55,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     libgles2-mesa-dev \
     ${GAZ} \
     lib${GAZ}-dev \
+    ros-${DIST}-compressed-image-transport \
     ros-${DIST}-ros-base \
     ros-${DIST}-xacro \
     ros-${DIST}-gazebo-ros \

--- a/vrx_server/vrx-server/gz_utils.sh
+++ b/vrx_server/vrx-server/gz_utils.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# gz_utils.sh: Utility functions used for running and playing back trials.
+
+function is_gzserver_running()
+{
+  if pgrep gzserver > /dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+# Check if gzclient is running
+function is_gzclient_running()
+{
+  if pgrep gzclient > /dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+function wait_until_gzserver_is_down()
+{
+  until ! is_gzserver_running
+  do
+    sleep 1
+  done
+}
+
+function wait_until_gzserver_is_up()
+{
+  until is_gzserver_running
+  do
+    sleep 1
+  done
+}

--- a/vrx_server/vrx-server/play_vrx_log.sh
+++ b/vrx_server/vrx-server/play_vrx_log.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+# play_vrx_log.sh: A shell script to play back Gazebo log file from a VRX
+# trial.
+
+# Get directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source ${DIR}/gz_utils.sh
+
+# Constants.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
+
+# Define usage function.
+usage()
+{
+  echo "Usage: $0 <log_file> <destination_file> [--keep-gz]"
+  echo "--manual-play: Do not automatically start playback. Wait for user to click in GUI."
+  echo "  By default, playack automatically starts."
+  echo "--keep-gz: Keep Gazebo server and client running after playback ends."
+  echo "  By default, they are shut down automatically."
+  exit 1
+}
+
+autoplay=1
+kill_gz=1
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+
+  case $key in
+    --manual-play)
+      autoplay=0
+      shift
+      ;;
+
+    --keep-gz)
+      kill_gz=0
+      shift
+      ;;
+
+    # Treat unknown options as positional args
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL[@]}"
+
+# Call usage() function if arguments not supplied.
+[[ $# -ne 2 ]] && usage
+
+LOG_FILE=$1
+OUTPUT=$2
+
+# Create a directory for the Gazebo log and the score file.
+DESTINATION_FOLDER="$(dirname "$OUTPUT")"
+if [ -d "$DESTINATION_FOLDER" ]; then
+  echo -e "${YELLOW}Wrn: Destination folder already exists. Data might be"\
+          "overwritten${NOCOLOR}\n"
+fi
+mkdir -p $DESTINATION_FOLDER
+
+echo "Starting Gazebo..."
+echo "Check any possible errors after the run in $OUTPUT.playback_output.txt..."
+
+# Start Gazebo in playback mode
+roslaunch vrx_gazebo playback.launch gui:=true log_file:=$LOG_FILE paused:=true verbose:=true \
+  > $OUTPUT.playback_output.txt 2>&1 &
+roslaunch_pid=$!
+wait_until_gzserver_is_up
+echo -e "${GREEN}OK${NOCOLOR}\n"
+
+echo "Waiting for server to start up"
+sleep 9s
+
+# Check if the log file has errors, likely forgot to source ws
+if grep -Fq "RLException" $OUTPUT.playback_output.txt
+then
+  echo "Failed to find playback launch file. Did you source your vrx_ws?"
+  exit 1
+fi
+
+wait_for_unpause_signal()
+{
+  echo "Waiting for unpause signal or manual unpause..."
+  gz_world_stats_topic=$(gz topic -l | grep "world_stats")
+
+  # Wait for Docker injection to unpause
+  until gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: false" --quiet
+  do
+    # If user manually closed Gazebo, no need to wait for host signal
+    if ! is_gzclient_running || ! is_gzserver_running ; then
+      echo "Detected gzserver or gzclient no longer running"
+      break
+    fi
+
+    sleep 1
+  done
+
+  echo -e "${GREEN}OK${NOCOLOR}"
+}
+
+if [ $autoplay -eq 1 ]; then
+  echo "Unpausing to start playback..."
+  gz world -p 0
+  echo -e "${GREEN}OK${NOCOLOR}"
+else
+  wait_for_unpause_signal
+fi
+
+echo "Playing back log file..."
+
+# Wait until the gazebo world stats topic (eg. /gazebo/<world>/world_stats)
+# tells us that the playback has been paused. This event will trigger the end of
+# the recording.
+wait_until_playback_ends()
+{
+  echo "Waiting for playback to end..."
+  gz_world_stats_topic=$(gz topic -l | grep "world_stats")
+
+  # Sleep until Gazebo is paused
+  until gz topic -e "$gz_world_stats_topic" -d 1 -u | grep "paused: true" --quiet
+  do
+    sleep 1
+    if ! is_gzclient_running ; then
+      echo 1>&2 "Detected gzclient no longer running"
+      return 0
+    fi
+  done
+  echo -e "${GREEN}OK${NOCOLOR}"
+}
+
+if [ $kill_gz -eq 1 ]; then
+  wait_until_playback_ends
+  killall -w gzserver gzclient
+else
+  echo "Waiting for Docker injection to terminate Gazebo..."
+  wait_until_gzserver_is_down
+fi
+
+# Kill rosnodes
+echo "Killing rosnodes"
+rosnode kill --all
+sleep 1s
+echo -e "${GREEN}OK${NOCOLOR}\n"
+
+# Kill roslaunch
+echo "Killing roslaunch pid: ${roslaunch_pid}"
+kill -INT ${roslaunch_pid}
+echo -e "${GREEN}OK${NOCOLOR}\n"

--- a/vrx_server/vrx-server/run_vrx_trial.sh
+++ b/vrx_server/vrx-server/run_vrx_trial.sh
@@ -40,7 +40,7 @@ echo "Starting vrx trial..."
 # Run the trial.
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
-roslaunch vrx_gazebo sandisland.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
+roslaunch vrx_gazebo vrx.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"

--- a/vrx_server/vrx-server/run_vrx_trial.sh
+++ b/vrx_server/vrx-server/run_vrx_trial.sh
@@ -2,31 +2,9 @@
 
 # run_vrx_trial.sh: A shell script to execute one vrx trial.
 
-is_gzserver_running()
-{
-  if pgrep gzserver >/dev/null; then
-    true
-  else
-    false
-  fi
-}
-
-wait_until_gzserver_is_down()
-{
-  until ! is_gzserver_running
-  do
-    sleep 1
-  done
-}
-
-
-wait_until_gzserver_is_up()
-{
-  until is_gzserver_running
-  do
-    sleep 1
-  done
-}
+# Get directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/gz_utils.sh
 
 set -e
 
@@ -62,7 +40,7 @@ echo "Starting vrx trial..."
 # Run the trial.
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
-roslaunch vrx_gazebo sandisland.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
+roslaunch vrx_gazebo sandisland.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"


### PR DESCRIPTION
- Backport #26 from VORC to VRX
- Backport #28 and #30 from VORC to VRX (very small fixes)
- Backport `robot_locked:=true` in launch command from VORC to VRX. Needed to eliminate errors like:
   ```
   [Err] [scoring_plugin.cc:235] Unable to release [wamv_external_pivot_joint]
   [Err] [scoring_plugin.cc:235] Unable to release [wamv_external_riser]
   ```
   Note for future: This is likely a patch, as only the stationkeeping task should really lock the vehicle. `scoring_plugin.cc` probably should be changed so that it does not attempt to release the locking joints, which are nonexistent for other tasks.

To test:

```
# Remove if exists
docker network rm vorc-network

# Rebuild image
./vrx_server/build_image.bash -n
# Prepare team
./prepare_team_wamv.bash example_team

# Change duration of stationkeeping0.world to 60 seconds to shorten test time.
vim generated/task_generated/stationkeeping/worlds/stationkeeping0.world 

# Run some task
./run_trial.bash -n example_team stationkeeping 0

# Test log playback
./replay_trial.bash -n example_team stationkeeping 0
# Test log recording
./generate_trial_video.bash -n example_team stationkeeping 0
```