### PR TITLE
New yaml for gymkhana task

### DIFF
--- a/task_config/gymkhana.yaml
+++ b/task_config/gymkhana.yaml
@@ -71,7 +71,7 @@ environment:
         1:
             ocean_waves:
                 - gain: 0.35
-                  period: 6.0
+                  period: 10.0
                   scale: 2.5
                   direction_x: 0.1
                   direction_y: 0.1

--- a/task_config/gymkhana.yaml
+++ b/task_config/gymkhana.yaml
@@ -1,0 +1,170 @@
+constant:
+    steps: 1
+    macros:
+        sydneyregatta_minus_scene: 
+            -
+    sequence:
+
+environment:
+    steps: 3
+    macros:
+        gymkhana:
+            -
+        ocean_waves:
+            -
+        usv_wind_gazebo:
+            -
+        scene_macro:
+            -
+    sequence:
+        0:
+            ocean_waves:
+                - gain: 0.0
+                  period: 5.0
+                  scale: 2.5
+                  direction_x: 1.0
+                  direction_y: 0.0
+            usv_wind_gazebo:
+                - mean_vel: 0.0
+                  var_gain: 0
+                  var_time: 1
+                  seed: 10
+                  direction: 240
+                  /**wind_objs: "
+                  <wind_obj>
+
+                  <name>wamv</name>
+
+                  <link_name>wamv/base_link</link_name>
+
+                  <coeff_vector>.5 .5 .33</coeff_vector>
+
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.85 0.85 0.85 1"
+            gymkhana:
+                - nav_uri: short_navigation_course0 
+                  obstacle_uri: obstacle_course0
+                  nx: -524
+                  ny: 186
+                  nY: -1.44
+                  ox: -477
+                  oy: 275
+                  oY: -2.54
+                  gx: -503
+                  gy: 302.5
+                  /**gates: "
+                  <gate>
+                    <left_marker>red_bound_0</left_marker>
+                    <right_marker>green_bound_0</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_1</left_marker>
+                    <right_marker>green_bound_1</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_2</left_marker>
+                    <right_marker>green_bound_2</right_marker>
+                  </gate>"
+
+        1:
+            ocean_waves:
+                - gain: 0.35
+                  period: 6.0
+                  scale: 2.5
+                  direction_x: 0.1
+                  direction_y: 0.1
+            usv_wind_gazebo:
+                - mean_vel: 5.0
+                  var_gain: 4.0
+                  var_time: 1
+                  seed: 7
+                  direction: 72
+                  /**wind_objs: "
+                  <wind_obj>
+
+                  <name>wamv</name>
+
+                  <link_name>wamv/base_link</link_name>
+
+                  <coeff_vector> .5 .5 .33</coeff_vector>
+
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.5 0.5 0.5 1"
+            gymkhana:
+                - nav_uri: short_navigation_course1
+                  obstacle_uri: obstacle_course1
+                  nx: -535
+                  ny: 180
+                  nY: -1.44
+                  ox: -500
+                  oy: 250
+                  oY: 0.44
+                  gx: -495
+                  gy: 265
+                  /**gates: "
+                  <gate>
+                    <left_marker>red_bound_0</left_marker>
+                    <right_marker>green_bound_0</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_1</left_marker>
+                    <right_marker>green_bound_1</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_2</left_marker>
+                    <right_marker>green_bound_2</right_marker>
+                  </gate>"
+        2:
+            ocean_waves:
+                - gain: 0.8
+                  period: 5.0
+                  scale: 2.5
+                  direction_x: -0.6
+                  direction_y: -0.32
+            usv_wind_gazebo:
+                - mean_vel: 9.0
+                  var_gain: 5.0
+                  var_time: 1
+                  seed: 19
+                  direction: 355
+                  /**wind_objs: "
+                  <wind_obj>
+
+                  <name>wamv</name>
+
+                  <link_name>wamv/base_link</link_name>
+
+                  <coeff_vector> .5 .5 .33</coeff_vector>
+
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.3 0.3 0.3 1"
+            gymkhana:
+                - nav_uri: short_navigation_course2
+                  obstacle_uri: obstacle_course2
+                  nx: -524
+                  ny: 186
+                  nY: -1.44
+                  ox: -530
+                  oy: 290
+                  oY: 1.17
+                  gx: -533
+                  gy: 293
+                  /**gates: "
+                  <gate>
+                    <left_marker>red_bound_0</left_marker>
+                    <right_marker>green_bound_0</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_1</left_marker>
+                    <right_marker>green_bound_1</right_marker>
+                  </gate>
+                  <gate>
+                    <left_marker>red_bound_2</left_marker>
+                    <right_marker>green_bound_2</right_marker>
+                  </gate>"

--- a/task_config/scan_dock_deliver.yaml
+++ b/task_config/scan_dock_deliver.yaml
@@ -44,7 +44,7 @@ environment:
                 - /**fog: ""
                   /**ambient: "0.89 0.89 0.89 1"
             scan_dock_deliver:
-                - model_name: dock_2022 
+                - model_name: robotx_dock_2022 
                   uri: dock_2022 
                   bay1_allowed: true
                   bay1_symbol: red_rectangle
@@ -92,7 +92,7 @@ environment:
                 - /**fog: ""
                   /**ambient: "0.52 0.52 0.52 1"
             scan_dock_deliver:
-                - model_name: dock_2022 
+                - model_name: robotx_dock_2022 
                   uri: dock_2022 
                   bay1_allowed: false
                   bay1_symbol: blue_rectangle
@@ -100,7 +100,7 @@ environment:
                   bay2_symbol: red_cross
                   bay3_allowed: true 
                   bay3_symbol: yellow_circle 
-                   x: -500
+                  x: -500
                   y: 190
                   z: 0
                   Y: 0
@@ -139,8 +139,8 @@ environment:
             scene_macro:
                 - /**fog: ""
                   /**ambient: "0.42 0.42 0.42 1"
-            dock:
-                - model_name: dock_2022 
+            scan_dock_deliver:
+                - model_name: robotx_dock_2022 
                   uri: dock_2022 
                   bay1_allowed: true 
                   bay1_symbol: red_cross
@@ -148,7 +148,7 @@ environment:
                   bay2_symbol: red_triangle
                   bay3_allowed: false 
                   bay3_symbol: red_triangle
-                   x: -540
+                  x: -540
                   y: 210 
                   z: 0
                   Y: 3.14

--- a/task_config/scan_dock_deliver.yaml
+++ b/task_config/scan_dock_deliver.yaml
@@ -1,0 +1,162 @@
+constant:
+    steps: 1
+    macros:
+        sydneyregatta_minus_scene: 
+            -
+    sequence:
+
+environment:
+    steps: 3
+    macros:
+        scan_dock_deliver:
+            -
+        ocean_waves:
+            -
+        usv_wind_gazebo:
+            -
+        scene_macro:
+            -
+    sequence:
+        0:
+            ocean_waves:
+                - gain: 0.0
+                  period: 5.0
+                  scale: 2.5
+                  direction_x: 1.0
+                  direction_y: 0.0
+            usv_wind_gazebo:
+                - mean_vel: 0.0
+                  var_gain: 0
+                  var_time: 1
+                  seed: 10
+                  direction: 240
+                  /**wind_objs: "
+                  <wind_obj>
+
+                  <name>wamv</name>
+
+                  <link_name>wamv/base_link</link_name>
+
+                  <coeff_vector>.5 .5 .33</coeff_vector>
+
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.89 0.89 0.89 1"
+            scan_dock_deliver:
+                - model_name: dock_2022 
+                  uri: dock_2022 
+                  bay1_allowed: true
+                  bay1_symbol: red_rectangle
+                  bay2_allowed: false
+                  bay2_symbol: blue_triangle
+                  bay3_allowed: false
+                  bay3_symbol: yellow_circle 
+                  x: -532
+                  y: 175
+                  z: 0.25
+                  Y: 0
+                  # Add light buoy and make sure that the light sequence 
+                  # is consistent with the allowed bay symbol
+                  light_buoy_present: true
+                  color_1: red
+                  color_2: green
+                  color_3: yellow
+                  lb_x: -532 
+                  lb_y: 190
+
+        1:
+            ocean_waves:
+                - gain: 0.2
+                  period: 9.0
+                  scale: 2.5
+                  direction_x: 0.35
+                  direction_y: -0.4
+            usv_wind_gazebo:
+                - mean_vel: 3.0
+                  var_gain: 2.0
+                  var_time: 1
+                  seed: 11
+                  direction: 96
+                  /**wind_objs: "
+                  <wind_obj>
+
+                  <name>wamv</name>
+
+                  <link_name>wamv/base_link</link_name>
+
+                  <coeff_vector> .5 .5 .33</coeff_vector>
+
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.52 0.52 0.52 1"
+            scan_dock_deliver:
+                - model_name: dock_2022 
+                  uri: dock_2022 
+                  bay1_allowed: false
+                  bay1_symbol: blue_rectangle
+                  bay2_allowed: false
+                  bay2_symbol: red_cross
+                  bay3_allowed: true 
+                  bay3_symbol: yellow_circle 
+                   x: -500
+                  y: 190
+                  z: 0
+                  Y: 0
+                  # Add light buoy and make sure that the light sequence 
+                  # is consistent with the allowed bay symbol
+                  light_buoy_present: true
+                  color_1: yellow
+                  color_2: blue
+                  color_3: red
+                  lb_x: -515
+                  lb_y: 180
+
+        2:
+            ocean_waves:
+                - gain: 0.2
+                  period: 9.0
+                  scale: 2.5
+                  direction_x: 0.35
+                  direction_y: -0.4
+            usv_wind_gazebo:
+                - mean_vel: 3.0
+                  var_gain: 2.0
+                  var_time: 1
+                  seed: 11
+                  direction: 96
+                  /**wind_objs: "
+                  <wind_obj>
+
+                  <name>wamv</name>
+
+                  <link_name>wamv/base_link</link_name>
+
+                  <coeff_vector> .5 .5 .33</coeff_vector>
+
+                  </wind_obj>"
+            scene_macro:
+                - /**fog: ""
+                  /**ambient: "0.42 0.42 0.42 1"
+            dock:
+                - model_name: dock_2022 
+                  uri: dock_2022 
+                  bay1_allowed: true 
+                  bay1_symbol: red_cross
+                  bay2_allowed: false
+                  bay2_symbol: red_triangle
+                  bay3_allowed: false 
+                  bay3_symbol: red_triangle
+                   x: -540
+                  y: 210 
+                  z: 0
+                  Y: 3.14
+                  # Add light buoy and make sure that the light sequence 
+                  # is consistent with the allowed bay symbol
+                  light_buoy_present: true
+                  color_1: yellow 
+                  color_2: red
+                  color_3: green
+                  lb_x: -510
+                  lb_y: 175

--- a/task_config/scan_dock_deliver.yaml
+++ b/task_config/scan_dock_deliver.yaml
@@ -54,7 +54,7 @@ environment:
                   bay3_symbol: yellow_circle 
                   x: -480
                   y: 190
-                  z: 0.25
+                  z: 0
                   Y: 1.0
                   # Add light buoy and make sure that the light sequence 
                   # is consistent with the allowed bay symbol
@@ -117,17 +117,17 @@ environment:
 
         2:
             ocean_waves:
-                - gain: 0.2
-                  period: 9.0
+                - gain: 0.5
+                  period: 4.0
                   scale: 2.5
-                  direction_x: 0.35
-                  direction_y: -0.4
+                  direction_x: 0.0
+                  direction_y: -1.0
             usv_wind_gazebo:
-                - mean_vel: 3.0
-                  var_gain: 2.0
+                - mean_vel: 8.0
+                  var_gain: 4.0
                   var_time: 1
-                  seed: 11
-                  direction: 96
+                  seed: 19
+                  direction: 17
                   /**wind_objs: "
                   <wind_obj>
 
@@ -140,7 +140,7 @@ environment:
                   </wind_obj>"
             scene_macro:
                 - /**fog: ""
-                  /**ambient: "0.42 0.42 0.42 1"
+                  /**ambient: "0.19 0.19 0.19 1"
             scan_dock_deliver:
                 - model_name: robotx_dock_2022 
                   uri: dock_2022 

--- a/task_config/scan_dock_deliver.yaml
+++ b/task_config/scan_dock_deliver.yaml
@@ -52,10 +52,10 @@ environment:
                   bay2_symbol: blue_triangle
                   bay3_allowed: false
                   bay3_symbol: yellow_circle 
-                  x: -532
-                  y: 175
+                  x: -480
+                  y: 190
                   z: 0.25
-                  Y: 0
+                  Y: 1.0
                   # Add light buoy and make sure that the light sequence 
                   # is consistent with the allowed bay symbol
                   light_buoy_present: true
@@ -63,7 +63,8 @@ environment:
                   color_2: green
                   color_3: yellow
                   lb_x: -532 
-                  lb_y: 190
+                  lb_y: 175
+                  lb_z: 0.25
 
         1:
             ocean_waves:
@@ -112,6 +113,7 @@ environment:
                   color_3: red
                   lb_x: -515
                   lb_y: 180
+                  lb_z: 0.25
 
         2:
             ocean_waves:
@@ -143,11 +145,11 @@ environment:
                 - model_name: robotx_dock_2022 
                   uri: dock_2022 
                   bay1_allowed: true 
-                  bay1_symbol: red_cross
+                  bay1_symbol: yellow_triangle
                   bay2_allowed: false
-                  bay2_symbol: red_triangle
+                  bay2_symbol: blue_cross
                   bay3_allowed: false 
-                  bay3_symbol: red_triangle
+                  bay3_symbol: green_rectangle 
                   x: -540
                   y: 210 
                   z: 0
@@ -160,3 +162,4 @@ environment:
                   color_3: green
                   lb_x: -510
                   lb_y: 175
+                  lb_z: 0.25


### PR DESCRIPTION
* This PR adds a gymkhana.yaml file that generates three practice worlds similar to the 3 stored in the vrx repository under `vrx_gazebo/worlds/2022_practice`.
* It requires the new file `gymkhana.xacro` in the vrx repository, so this PR must be tested in conjunction with [PR 392](https://github.com/osrf/vrx/pull/392) of that repository.

## How to test:
These instructions assume you have a workspace at `~/vrx_ws` with both vrx and vrx-docker installed, and have checked out the `M1chaelM/gymkhana_xacro` branch in vrx.
* First, switch to the root of the `vrx-docker` repository.  
  ```
  cd ~/vrx_ws/src/vrx-docker
  ```
* Set some variables for convenience:
  ```
  TASK=gymkhana
  TRIAL=0
  ```
* Generate the trial worlds for the task
  ```
  ./prepare_task_trials.bash $TASK
  ```
* Verify that 3 worlds are generated without errors (except the expected `REQUIRED process [world_gen-2] has died!` message).
* Now for each trial, 0-2
    * Test that the generated world runs:
      ```
      roslaunch vrx_gazebo vrx.launch world:=`pwd`/generated/task_generated/${TASK}/worlds/${TASK}${TRIAL}.world verbose:=true wamv_locked:=true
      ```
    * Check that the generated world matches the corresponding world in `vrx/vrx_gazebo/worlds/2022_practice` in all important details. The way I do this is by looking at the diff with vimdiff. For example:
      ```
      cd ~/vrx_ws/src/
      vimdiff vrx-docker/generated/task_generated/${TASK}/worlds/${TASK}${TRIAL}.world 
      vrx/vrx_gazebo/worlds/2022_practice/${TASK}${TRIAL}.world
      ```
