### PR TITLE
Updated environment variable for properly ending tasks

### DIFF
--- a/run_trial.bash
+++ b/run_trial.bash
@@ -152,7 +152,7 @@ ${DIR}/vrx_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERVE
   -v ${HOST_LOG_DIR}:${LOG_DIR} \
   -e ROS_MASTER_URI=${ROS_MASTER_URI} \
   -e ROS_IP=${SERVER_ROS_IP} \
-  -e VRX_EXIT_ON_COMPLETION=true \
+  -e VRX_EXIT_ON_COMPLETION=false \
   -e VRX_DEBUG=false" \
   "${SERVER_CMD}" &
 SERVER_PID=$!


### PR DESCRIPTION
I believe this could be a potential solution for allowing the gymkhana task to finish. I am not the most familiar with the vrx-docker repository, however, setting ```VRX_EXIT_ON_COMPLETION``` to false seemed to allow my gymkhana task to finish the navigation subtask without killing gazebo. It also did not cause any issues with other tasks. It seems to me that the ```per_plugin_exit_on_completion``` attribute effectively replaces this environment variable, so it may be possible to remove the environment variable all together (this would involve removing the check for it in the scoring_plugin.cc of the vrx repository). This is all in reference to #45.