### PR TITLE
Phase2 updates

### DIFF
--- a/multi_scripts/run_one_team_all_tasks.bash
+++ b/multi_scripts/run_one_team_all_tasks.bash
@@ -72,7 +72,7 @@ done
 # Record team score if all tasks successful
 if [ "$successful_team" = true ]; then
   echo "${TEAM_NAME} has completed all tasks. Creating text file for team score"
-  python ${DIR}/../utils/get_team_score.py $TEAM_NAME
+  python3 ${DIR}/../utils/get_team_score.py $TEAM_NAME
   exit_status=$?
   
   # Print OK or FAIL message

--- a/multi_scripts/run_one_team_one_task.bash
+++ b/multi_scripts/run_one_team_one_task.bash
@@ -95,7 +95,7 @@ done
 # Record task score if all trials successful
 if [ "$successful_task" = true ]; then
   echo "All $TASK_NAME trials completed. Creating text file for task score"
-  python ${DIR}/../utils/get_task_score.py $TEAM_NAME $TASK_NAME
+  python3 ${DIR}/../utils/get_task_score.py $TEAM_NAME $TASK_NAME
   exit_status=$?
   
   # Print OK or FAIL message

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -152,7 +152,6 @@ ${DIR}/vrx_server/run_container.bash $nvidia_arg ${SERVER_CONTAINER_NAME} $SERVE
   -v ${HOST_LOG_DIR}:${LOG_DIR} \
   -e ROS_MASTER_URI=${ROS_MASTER_URI} \
   -e ROS_IP=${SERVER_ROS_IP} \
-  -e VRX_EXIT_ON_COMPLETION=true \
   -e VRX_DEBUG=false" \
   "${SERVER_CMD}" &
 SERVER_PID=$!


### PR DESCRIPTION
This patch makes two changes:

* Replace the call to `python <python_file>` with `python3 <python_file>`. We updated `run_trial.bash` but there were two other scripts that need to be updated.

* Do not set the the environment variable `VRX_EXIT_ON_COMPLETION` to `true` when running a trial. This is problematic in the gymkhana task. The gymkhana task loads two other scoring plugins as auxiliary plugins. The `navigation_scoring_plugin` is used to detect when the WAM-V crosses the navigation channel. The `stationkeeping_scoring_plugin` is used to compute the error between the WAM-V and the pinger position. These two plugins have the `<per_plugin_exit_on_completion>` SDF parameter set to `false`. This is to prevent that the simulation terminates when the navigation channel is crossed. However, and this is the real issue, the environment variable `VRX_EXIT_ON_COMPLETION` overwrites the value of this parameter. This causes the gymkhana task to finish prematurely when the navigation channel is crossed. The solution is to not set the environment variable, as the default value for exit on completion is `true` (see `scoring_plugin.hh`). This way when the `<per_plugin_exit_on_completion>` is set to false won't be overwritten.

How to test it? It's a bit difficult to test using `run_vrx_trial.sh`, so the following instructions confirm the issue and verify that without setting the environment variable everything works as expected.

You can launch a gymkhana task:

```
export VRX_EXIT_ON_COMPLETION=true
roslaunch vrx_gazebo gymkhana.launch
```

Launch a teleoperation node:
```
roslaunch vrx_gazebo usv_joydrive.launch
```

And cross the navigation course. You will observe that the simulation terminates when you complete the course. This is not expected as you still need to go to the pinger location.

Now, you can repeat the process without the environment variable set.

```
unset VRX_EXIT_ON_COMPLETION
```

You should observe that you can continue the task after completing the navigation course. The task should still finish when the running time expires.