### PR TITLE
Fix wamv_locked parameter name

### DIFF
--- a/mwes/2022/vrx_2022_simple/basic_node.py
+++ b/mwes/2022/vrx_2022_simple/basic_node.py
@@ -65,7 +65,7 @@ class SimpleNode:
 
     def sendCmds(self):
         tasklist = ("station_keeping", "wayfinding", "gymkhana",
-                                       "wildlife","scan_dock_deliver")
+                    "perception", "wildlife","scan_dock_deliver")
         while not rospy.is_shutdown():
             try:
                 if isinstance(self.taskInfo, type(self.taskType)):

--- a/prepare_team_wamv.bash
+++ b/prepare_team_wamv.bash
@@ -85,7 +85,7 @@ mkdir -p ${wamv_target_dir}
 
 # Generate WAM-V
 echo "Generating WAM-V..."
-roslaunch vrx_gazebo generate_wamv.launch component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target
+roslaunch vrx_gazebo generate_wamv.launch component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
 echo -e "${GREEN}OK${NOCOLOR}\n"
 
 # Write to text file about compliance

--- a/vrx_server/vrx-server/run_vrx_trial.sh
+++ b/vrx_server/vrx-server/run_vrx_trial.sh
@@ -40,7 +40,7 @@ echo "Starting vrx trial..."
 # Run the trial.
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
-roslaunch vrx_gazebo vrx.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true robot_locked:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
+roslaunch vrx_gazebo vrx.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true wamv_locked:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"

--- a/vrx_server/vrx-server/run_vrx_trial.sh
+++ b/vrx_server/vrx-server/run_vrx_trial.sh
@@ -40,7 +40,7 @@ echo "Starting vrx trial..."
 # Run the trial.
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
-roslaunch vrx_gazebo vrx.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true wamv_locked:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
+roslaunch vrx_gazebo vrx.launch gui:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gazebo_args:="-r --record_period ${RECORD_PERIOD} --record_path $HOME/.gazebo" verbose:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"


### PR DESCRIPTION
When launching a task, we were passing `robot_locked` instead of `wamv_locked`.
