### PR TITLE
Update component_config.yaml and thruster_config.yaml to be consistent with VRX WAM-V configuration

### DIFF
--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -59,3 +59,6 @@ wamv_ball_shooter:
       z: 1.3
       pitch: ${radians(-20)}
       yaw: 0.0
+wamv_pinger:
+    - name: pinger
+      position: 1.0 0 -1.0

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -54,8 +54,8 @@ lidar:
       post_Y: 0.0
 wamv_ball_shooter:
     - name: ball_shooter
-      x: 0.5
-      y: -0.25
+      x: 0.55 
+      y: -0.3 
       z: 1.3
       pitch: ${radians(-20)}
-      yaw: 0
+      yaw: 0.0

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -45,7 +45,13 @@ wamv_imu:
 lidar:
     - name: lidar_wamv
       type: 16_beam
+      x: 0.7
+      y: 0.0
+      z: 1.8
+      R: 0.0
       P: ${radians(8)}
+      Y: 0.0
+      post_Y: 0.0
 wamv_ball_shooter:
     - name: ball_shooter
       x: 0.5

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -36,7 +36,12 @@ wamv_gps:
       Y: 0.0
 wamv_imu:
     - name: imu_wamv
+      x: 0.3
       y: -0.2
+      z: 1.3
+      R: 0.0
+      P: 0.0
+      Y: 0.0
 lidar:
     - name: lidar_wamv
       type: 16_beam

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -29,6 +29,11 @@ wamv_camera:
 wamv_gps:
     - name: gps_wamv
       x: -0.85
+      y: 0.0
+      z: 1.3
+      R: 0.0
+      P: 0.0
+      Y: 0.0
 wamv_imu:
     - name: imu_wamv
       y: -0.2

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -8,6 +8,15 @@ wamv_camera:
       P: ${radians(15)}
       Y: 0.0
       post_Y: 0.0
+    - name: front_right_camera
+      visualize: False
+      x: 0.75
+      y: -0.1
+      z: 1.5
+      R: 0.0
+      P: ${radians(15)}
+      Y: 0.0
+      post_Y: 0.0
 wamv_gps:
     - name: gps_wamv
       x: -0.85

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -17,6 +17,15 @@ wamv_camera:
       P: ${radians(15)}
       Y: 0.0
       post_Y: 0.0
+    - name: far_left_camera
+      visualize: False
+      x: 0.75
+      y: 0.3
+      z: 1.5
+      R: 0.0
+      P: ${radians(15)}
+      Y: 0.0
+      post_Y: 0.0
 wamv_gps:
     - name: gps_wamv
       x: -0.85

--- a/team_config/example_team/component_config.yaml
+++ b/team_config/example_team/component_config.yaml
@@ -1,8 +1,13 @@
 wamv_camera:
-    - name: front_camera
+    - name: front_left_camera
+      visualize: False
       x: 0.75
-      y: 0.0
+      y: 0.1
+      z: 1.5
+      R: 0.0
       P: ${radians(15)}
+      Y: 0.0
+      post_Y: 0.0
 wamv_gps:
     - name: gps_wamv
       x: -0.85

--- a/team_config/example_team/thruster_config.yaml
+++ b/team_config/example_team/thruster_config.yaml
@@ -5,6 +5,3 @@ engine:
   - prefix: "right"
     position: "-2.373776 -1.027135 0.318237"
     orientation: "0.0 0.0 0.0"
-  - prefix: "middle"
-    position: "0 0 0.318237"
-    orientation: "0.0 0.0 0.0"


### PR DESCRIPTION
There were a few inconsistencies between the [`component_config.yaml`](https://github.com/osrf/vrx-docker/blob/master/team_config/example_team/component_config.yaml) and [`thruster_config.yaml`](https://github.com/osrf/vrx-docker/blob/master/team_config/example_team/thruster_config.yaml) of the [`vrx-docker`](https://github.com/osrf/vrx-docker/tree/master/team_config/example_team) repository as compared with [`example_component_config.yaml`](https://github.com/osrf/vrx/blob/master/vrx_gazebo/config/wamv_config/example_component_config.yaml) and [`example_thruster_config.yaml`](https://github.com/osrf/vrx/blob/master/vrx_gazebo/config/wamv_config/example_thruster_config.yaml) of the [`vrx`](https://github.com/osrf/vrx/tree/master/vrx_gazebo/config/wamv_config) repository.

This PR resolves the aforementioned inconsistencies and adds the pinger component to the `component_config.yaml`. For details, please refer https://github.com/osrf/vrx/pull/448.