### PR TITLE
explicitly specify vrx 1.6.1

### DIFF
--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -108,7 +108,7 @@ RUN mkdir -p vrx_ws/src
 # Copy the VRX repository from the local file system
 # We can't use the USER:GROUP variables until Docker adds support to --chown
 # COPY --chown=developer:developer . vrx_ws/src/vrx/
-RUN git clone https://github.com/osrf/vrx.git
+RUN git clone -b 1.6.1 https://github.com/osrf/vrx.git 
 RUN mv ./vrx ./vrx_ws/src
 
 # Compile the VRX project.


### PR DESCRIPTION
Our Dockerfile for the vrx-server clones the vrx repository directly from github. This practice is somewhat error prone because the image will not detect updates to the repository. By default it will instead cache the version that was present whenever the first time it was run, which means it is easy to accidentally end up testing against old code.

This PR addresses this issue by explicitly setting the version of the vrx repository to 1.6.1, which is the version of VRX that the 2022 competition will be run against. In future competitions it will need to be updated manually (or we can think of a better way to do this).

To test:
1. Rebuild the vrx-server:
  ```
  cd ~/vrx_ws/src/vrx-docker
  vrx_server/build_image.bash -n
  ```

2. Verify that the new version of the code is there:
  ```
  docker run -it --entrypoint=/bin/bash vrx-server-noetic-nvidia:latest
  head vrx_ws/src/vrx/Changelog.md
  ```
  You should see entries for 1.6.1.
  
3. Exit the container:
  ```
  exit
  ```

4. Run a trial of the gymkhana task world 0 with our example team:
  ```
  ./run_trial.bash example_team gymhkhana 0
  ```
  Verify that the score is 268:
  ```
  cat generated/logs/example_team/gymkhana/0/trial_score.txt 
  ```
  (This score represents the maximum distance of 200 plus 68 collisions from driving in a straight line into the shore.)

