### PR TITLE
[Garden] Update prepare_team_wamv.bash

### DIFF
--- a/prepare_team_wamv.bash
+++ b/prepare_team_wamv.bash
@@ -50,6 +50,11 @@ usage()
 
 TEAM_NAME=$1
 
+if [[ -z "${ROS_HOME}" ]]; then
+  echo "Environment variable ROS_HOME not set."
+  exit 1
+fi
+
 echo -e "${GREEN}Preparing WAM-V URDF for team: ${TEAM_NAME}${NOCOLOR}"
 
 # Get directory of this file

--- a/prepare_team_wamv.bash
+++ b/prepare_team_wamv.bash
@@ -17,7 +17,7 @@ NOCOLOR='\033[0m'
 is_wamv_compliant()
 {
   # Get logs
-  log_dir=$HOME/.ros/log
+  log_dir=$ROS_HOME/log
   logs=$(ls -t $log_dir)
 
   # Find latest wamv_generator log

--- a/prepare_team_wamv.bash
+++ b/prepare_team_wamv.bash
@@ -17,7 +17,7 @@ NOCOLOR='\033[0m'
 is_wamv_compliant()
 {
   # Get logs
-  log_dir=$HOME/.ros/log/latest
+  log_dir=$HOME/.ros/log
   logs=$(ls -t $log_dir)
 
   # Find latest wamv_generator log
@@ -85,7 +85,7 @@ mkdir -p ${wamv_target_dir}
 
 # Generate WAM-V
 echo "Generating WAM-V..."
-roslaunch vrx_gazebo generate_wamv.launch component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
+ros2 launch vrx_gazebo generate_wamv.launch.py component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
 echo -e "${GREEN}OK${NOCOLOR}\n"
 
 # Write to text file about compliance


### PR DESCRIPTION
This pull request updates the `prepare_team_wamv.bash` script to be used with Gazebo.

How to test it?

* Install VRX
* Set the ROS_HOME environment variable
```
export ROS_HOME=~/.ros
```
* Remember to source all the VRX `setup.bash`. E.g.:
```
. /opt/ros/humble/setup.bash
. ~/garden_ws/install/setup.bash
. ~/vrx2023_ws/install/setup.bash
```
* Run the script:
```
./prepare_team_wamv.bash example_team
```
* Launch the simulation with the generated WAM-V (update the `urdf` parameter with the path to your vrx-docker project:
```
ros2 launch vrx_gz competition.launch.py world:=sydney_regatta urdf:=/home/caguero/workspace/vrx-docker/generated/team_generated/example_team/example_team.urdf
```