### PR TITLE
updated vrx-server to jammy/humble/garden

### DIFF
--- a/prepare_team_wamv.bash
+++ b/prepare_team_wamv.bash
@@ -85,7 +85,7 @@ mkdir -p ${wamv_target_dir}
 
 # Generate WAM-V
 echo "Generating WAM-V..."
-roslaunch vrx_gazebo generate_wamv.launch component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
+ros2 launch vrx_gazebo generate_wamv.launch.py component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
 echo -e "${GREEN}OK${NOCOLOR}\n"
 
 # Write to text file about compliance

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -107,10 +107,10 @@ else
 fi
 
 COMP_GENERATED_DIR=${DIR}/generated/task_generated/${TASK_NAME}
-if [ -f "${COMP_GENERATED_DIR}/worlds/${TASK_NAME}${TRIAL_NUM}.world" ]; then
-  echo "Successfully found: ${COMP_GENERATED_DIR}/worlds/${TASK_NAME}${TRIAL_NUM}.world"
+if [ -f "${COMP_GENERATED_DIR}/worlds/${TASK_NAME}${TRIAL_NUM}.sdf" ]; then
+  echo "Successfully found: ${COMP_GENERATED_DIR}/worlds/${TASK_NAME}${TRIAL_NUM}.sdf"
 else
-  echo -e "${RED}Err: ${COMP_GENERATED_DIR}/worlds/${TASK_NAME}${TRIAL_NUM}.world not found."; exit 1;
+  echo -e "${RED}Err: ${COMP_GENERATED_DIR}/worlds/${TASK_NAME}${TRIAL_NUM}.sdf not found."; exit 1;
 fi
 
 # Ensure any previous containers are killed and removed.

--- a/vrx_server/build_image.bash
+++ b/vrx_server/build_image.bash
@@ -19,44 +19,18 @@ NOCOLOR='\033[0m'
 # Get directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Setup docker args
-USERID=`id -u`
-GROUPID=`id -g`
-if [[ ${USERID} != 0 ]]; then
-  DOCKER_ARGS="--build-arg USERID=${USERID} --build-arg GROUPID=${GROUPID}"
-fi
-
 # DOCKER_ARGS="$DOCKER_ARGS --no-cache"
 
 # Parse arguments
 BUILD_BASE=""
 image_name="vrx-server-jammy"
 
-# Parse args related to NVIDIA
-POSITIONAL=()
-while [[ $# -gt 0 ]]
-do
-    key="$1"
-
-    case $key in
-        -n|--nvidia)
-        BUILD_BASE="--build-arg BASEIMG=nvidia/cuda:11.8.0-devel-ubuntu22.04"
-        image_name="$image_name-nvidia"
-        shift
-        ;;
-        *)    # unknown option
-        POSITIONAL+=("$1")
-        shift
-        ;;
-    esac
-done
-
 set -- "${POSITIONAL[@]}"
 
 # Usage
 if [ $# -gt 0 ]
 then
-    echo "Usage: $0 [-n --nvidia]"
+    echo "Usage: $0 "
     exit 1
 fi
 
@@ -64,7 +38,7 @@ fi
 echo "Build image: $image_name"
 set -x
 image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
-docker build --force-rm ${DOCKER_ARGS} --tag $image_plus_tag --build-arg USER=$USER --build-arg GROUP=$USER $BUILD_BASE $DIR/vrx-server && \
+docker build --force-rm ${DOCKER_ARGS} --tag $image_plus_tag $BUILD_BASE $DIR/vrx-server && \
 docker tag $image_plus_tag $image_name:latest && \
 echo "Built $image_plus_tag and tagged as $image_name:latest"
 

--- a/vrx_server/build_image.bash
+++ b/vrx_server/build_image.bash
@@ -30,7 +30,7 @@ fi
 
 # Parse arguments
 BUILD_BASE=""
-image_name="vrx-server-noetic"
+image_name="vrx-server-jammy"
 
 # Parse args related to NVIDIA
 POSITIONAL=()
@@ -40,7 +40,7 @@ do
 
     case $key in
         -n|--nvidia)
-        BUILD_BASE="--build-arg BASEIMG=nvidia/opengl:1.0-glvnd-devel-ubuntu20.04"
+        BUILD_BASE="--build-arg BASEIMG=nvidia/cuda:11.8.0-devel-ubuntu22.04"
         image_name="$image_name-nvidia"
         shift
         ;;

--- a/vrx_server/build_image.bash
+++ b/vrx_server/build_image.bash
@@ -19,7 +19,7 @@ NOCOLOR='\033[0m'
 # Get directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# DOCKER_ARGS="$DOCKER_ARGS --no-cache"
+DOCKER_ARGS="$DOCKER_ARGS --no-cache"
 
 # Parse arguments
 BUILD_BASE=""

--- a/vrx_server/run_container.bash
+++ b/vrx_server/run_container.bash
@@ -71,10 +71,10 @@ fi
 chmod a+r $XAUTH
 
 docker run --name ${CONTAINER} \
-  -e XAUTHORITY=$XAUTH \
   -e DISPLAY \
   -e TERM \
   -e QT_X11_NO_MITSHM=1 \
+  -e XAUTHORITY=$XAUTH \
   -v "$XAUTH:$XAUTH" \
   -v "/tmp/.X11-unix:/tmp/.X11-unix" \
   -v "/etc/localtime:/etc/localtime:ro" \

--- a/vrx_server/run_container.bash
+++ b/vrx_server/run_container.bash
@@ -85,7 +85,6 @@ docker run --name ${CONTAINER} \
   --gpus all \
   --privileged \
   --security-opt seccomp=unconfined \
-  -u $USERID:$GROUPID \
   ${DOCKER_EXTRA_ARGS} \
   ${IMAGE_NAME} \
 ${COMMAND}

--- a/vrx_server/run_container.bash
+++ b/vrx_server/run_container.bash
@@ -79,10 +79,10 @@ docker run --name ${CONTAINER} \
   -v "$XAUTH:$XAUTH" \
   -v "/tmp/.X11-unix:/tmp/.X11-unix" \
   -v "/etc/localtime:/etc/localtime:ro" \
-  -v "/tmp/.docker.xauth:/tmp/.docker.xauth" \
+  -v "/tmp/.dockerifvefjga.xauth:/tmp/.dockerifvefjga.xauth" \
   -v /dev/log:/dev/log \
   -v "/dev/input:/dev/input" \
-  --runtime=$RUNTIME \
+  --gpus all \
   --privileged \
   --security-opt seccomp=unconfined \
   -u $USERID:$GROUPID \

--- a/vrx_server/run_container.bash
+++ b/vrx_server/run_container.bash
@@ -36,6 +36,7 @@ do
       ;;
       *)    # unknown option
       POSITIONAL+=("$1")
+[ruby $(which gz) sim-1] qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
       shift
       ;;
   esac
@@ -45,6 +46,7 @@ set -- "${POSITIONAL[@]}"
 
 if [[ $# -lt 2 ]] 
 then
+[ruby $(which gz) sim-1] qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
     echo "Usage: $0 [-n --nvidia] <container_name> <image_name> [<docker_extra_args> <command>]"
     exit 1
 fi
@@ -56,30 +58,26 @@ COMMAND=$4
 
 # Make sure processes in the container can connect to the x server
 # Necessary so gazebo can create a context for OpenGL rendering (even headless)
-XAUTH=/tmp/.docker.xauth
+XAUTH=/tmp/.dockervrx.xauth
 if [ ! -f $XAUTH ]
 then
-    xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')
-    if [ ! -z "$xauth_list" ]
-    then
-        echo $xauth_list | xauth -f $XAUTH nmerge -
-    else
-        touch $XAUTH
-    fi
-    chmod a+r $XAUTH
+    touch $XAUTH
 fi
-
-USERID=$(id -u)
-GROUPID=$(id -g)
+xauth_list=$(xauth nlist $DISPLAY | sed -e 's/^..../ffff/')
+if [ ! -z "$xauth_list" ]
+then
+    echo $xauth_list | xauth -f $XAUTH nmerge -
+fi
+chmod a+r $XAUTH
 
 docker run --name ${CONTAINER} \
   -e XAUTHORITY=$XAUTH \
-  --env="DISPLAY" \
-  --env="QT_X11_NO_MITSHM=1" \
+  -e DISPLAY \
+  -e TERM \
+  -e QT_X11_NO_MITSHM=1 \
   -v "$XAUTH:$XAUTH" \
   -v "/tmp/.X11-unix:/tmp/.X11-unix" \
   -v "/etc/localtime:/etc/localtime:ro" \
-  -v "/tmp/.dockerifvefjga.xauth:/tmp/.dockerifvefjga.xauth" \
   -v /dev/log:/dev/log \
   -v "/dev/input:/dev/input" \
   --gpus all \

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -9,12 +9,10 @@ RUN mkdir -p ~/vrx_ws/src
 
 # TODO: restore version tag
 RUN git clone https://github.com/osrf/vrx.git \
-&& git clone https://github.com/gazebosim/ros_gz.git -b humble \
-&& mv ./vrx ./vrx_ws/src \
-&& mv ./ros_gz ./vrx_ws/src
+&& mv ./vrx ./vrx_ws/src
 
 # Compile the VRX project.
-RUN /bin/bash -c ". /opt/ros/${ROSDIST}/setup.bash && cd vrx_ws && GZ_VERSION=garden colcon build --merge-install"
+RUN /bin/bash -c ". /opt/ros/${ROSDIST}/setup.bash && cd vrx_ws && colcon build --merge-install"
 
 # Source all the needed environment files.
 RUN /bin/sh -c 'echo ". /opt/ros/${ROSDIST}/setup.bash" >> ~/.bashrc' \

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -1,11 +1,13 @@
-ARG BASEIMG=ubuntu:focal
+ARG BASEIMG=ubuntu:jammy
 FROM $BASEIMG
 
 # Set ROS distribution
-ARG DIST=noetic
+ARG ROSDIST=humble
 
 # Set Gazebo verison
-ARG GAZ=gazebo11
+ARG GZDIST=garden
+
+ENV GZ_VERSION garden
 
 RUN export DEBIAN_FRONTEND=noninteractive \
  && apt update \
@@ -40,34 +42,38 @@ RUN export DEBIAN_FRONTEND=noninteractive \
          sudo \
          vim \
          wget \
+         libgflags-dev \
   && apt clean
 
+
+
 # Get ROS and Gazebo
-RUN wget -P /tmp/ http://packages.osrfoundation.org/gazebo.key
-RUN wget -P /tmp/ http://packages.ros.org/ros.key
-RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
- && apt-key add /tmp/ros.key \
- && /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list' \
- && apt-key add /tmp/gazebo.key \
- && apt update \
- && apt install -y \
-    ${GAZ} \
-    lib${GAZ}-dev \
-    ros-${DIST}-compressed-image-transport \
-    ros-${DIST}-ros-base \
-    ros-${DIST}-gazebo-plugins \
-    ros-${DIST}-gazebo-ros \
-    ros-${DIST}-hector-gazebo-plugins \
-    ros-${DIST}-joy \
-    ros-${DIST}-joy-teleop \
-    ros-${DIST}-key-teleop \
-    ros-${DIST}-robot-localization \
-    ros-${DIST}-robot-state-publisher \
-    ros-${DIST}-rviz \
-    ros-${DIST}-teleop-tools \
-    ros-${DIST}-teleop-twist-keyboard \
-    ros-${DIST}-velodyne-simulator \
-    ros-${DIST}-xacro \
+# Install ignition fortress and ROS2 Desktop
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null' \
+  && /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \
+  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null' \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     gz-${GZDIST} \
+     ros-${ROSDIST}-desktop \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq
+
+RUN apt update \
+ && apt install -y --no-install-recommends \
+    python3-colcon-common-extensions \
+    python3-sdformat13 \
+    ros-${ROSDIST}-compressed-image-transport \
+    ros-${ROSDIST}-joy \
+    ros-${ROSDIST}-joy-teleop \
+    ros-${ROSDIST}-key-teleop \
+    ros-${ROSDIST}-robot-localization \
+    ros-${ROSDIST}-robot-state-publisher \
+    ros-${ROSDIST}-rviz2 \
+    ros-${ROSDIST}-teleop-tools \
+    ros-${ROSDIST}-teleop-twist-keyboard \
+    ros-${ROSDIST}-xacro \
  && apt clean
 
 # Removed
@@ -108,11 +114,13 @@ RUN mkdir -p vrx_ws/src
 # Copy the VRX repository from the local file system
 # We can't use the USER:GROUP variables until Docker adds support to --chown
 # COPY --chown=developer:developer . vrx_ws/src/vrx/
-RUN git clone -b 1.6.2 https://github.com/osrf/vrx.git 
-RUN mv ./vrx ./vrx_ws/src
+RUN git clone -b 2.0.0 https://github.com/osrf/vrx.git \
+&& git clone https://github.com/gazebosim/ros_gz.git -b humble \
+&& mv ./vrx ./vrx_ws/src \
+&& mv ./ros_gz ./vrx_ws/src
 
 # Compile the VRX project.
-RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash && cd vrx_ws && catkin_make"
+RUN /bin/bash -c ". /opt/ros/${ROSDIST}/setup.bash && cd vrx_ws && GZ_VERSION=garden colcon build --merge-install"
 
 # Source all the needed environment files.
 RUN /bin/sh -c 'echo ". /opt/ros/${DIST}/setup.bash" >> ~/.bashrc' \
@@ -131,13 +139,6 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_P
 # Set encoding to use unicode characters
 # RUN sudo locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
-
-# Takes too long to do, probably not needed
-# Get gazebo models early since it is big
-# RUN wget -P /tmp/ https://bitbucket.org/osrf/gazebo_models/get/default.tar.gz \
-#  && mkdir -p $HOME/.gazebo/models \
-#  && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
-#  && rm /tmp/default.tar.gz
 
 # setup entrypoint
 COPY ./vrx_entrypoint.sh /

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -1,120 +1,14 @@
-ARG BASEIMG=ubuntu:jammy
+ARG BASEIMG=npslearninglab/watery_robots:vrx_current
 FROM $BASEIMG
 
 # Set ROS distribution
 ARG ROSDIST=humble
 
-# Set Gazebo verison
-ARG GZDIST=garden
-
-ENV GZ_VERSION garden
-
-RUN export DEBIAN_FRONTEND=noninteractive \
- && apt update \
- && apt install -y \
-    tzdata \
- && ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime \
- && dpkg-reconfigure --frontend noninteractive tzdata \
- && apt clean
-
-# Tools useful during development.
- RUN apt update \
-  && apt install -y \
-         build-essential \
-         cmake \
-         cppcheck \
-         curl \
-         git \
-         language-pack-en \
-         libeigen3-dev \
-         libgles2-mesa-dev \
-         lsb-release \
-         gdb \
-         mercurial \
-         pkg-config \
-         psmisc \
-         python3-dbg \
-         python3-pip \
-         python3-venv \
-         qtbase5-dev \
-         ruby \
-         software-properties-common \
-         sudo \
-         vim \
-         wget \
-         libgflags-dev \
-  && apt clean
-
-
-
-# Get ROS and Gazebo
-# Install ignition fortress and ROS2 Desktop
-RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
-  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null' \
-  && /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \
-  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null' \
-  && apt update \
-  && apt install -y --no-install-recommends \
-     gz-${GZDIST} \
-     ros-${ROSDIST}-desktop \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean -qq
-
-RUN apt update \
- && apt install -y --no-install-recommends \
-    python3-colcon-common-extensions \
-    python3-sdformat13 \
-    ros-${ROSDIST}-compressed-image-transport \
-    ros-${ROSDIST}-joy \
-    ros-${ROSDIST}-joy-teleop \
-    ros-${ROSDIST}-key-teleop \
-    ros-${ROSDIST}-robot-localization \
-    ros-${ROSDIST}-robot-state-publisher \
-    ros-${ROSDIST}-rviz2 \
-    ros-${ROSDIST}-teleop-tools \
-    ros-${ROSDIST}-teleop-twist-keyboard \
-    ros-${ROSDIST}-xacro \
- && apt clean
-
-# Removed
-#    python-rosdep \
-# && rosdep init \
-# RUN rosdep update
-
-# Set USER and GROUP
-ARG USER=developer
-ARG GROUP=developer
-ARG USERID=1000
-ARG GROUPID=1000
-
-# Add a user with the same user_id as the user outside the container
-# Requires a docker build argument `user_id`.
-
-RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
-    chown root:root /usr/local/bin/fixuid && \
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
-
-RUN addgroup --gid $GROUPID $USER && \
-    useradd --no-log-init --create-home --uid $USERID --gid $GROUPID --home-dir /home/$USER --shell /bin/sh -c "" $USER
-
-RUN adduser $USER sudo \
- && echo "$USER ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USER
-
-# Commands below run as the developer user.
-USER $USER:$GROUP
-
-# When running a container start in the developer's home folder.
-WORKDIR /home/$USER
-
 # Create workspace
 RUN mkdir -p vrx_ws/src
 
-# Copy the VRX repository from the local file system
-# We can't use the USER:GROUP variables until Docker adds support to --chown
-# COPY --chown=developer:developer . vrx_ws/src/vrx/
-RUN git clone -b 2.0.0 https://github.com/osrf/vrx.git \
+# TODO: restore version tag
+RUN git clone https://github.com/osrf/vrx.git \
 && git clone https://github.com/gazebosim/ros_gz.git -b humble \
 && mv ./vrx ./vrx_ws/src \
 && mv ./ros_gz ./vrx_ws/src
@@ -123,22 +17,12 @@ RUN git clone -b 2.0.0 https://github.com/osrf/vrx.git \
 RUN /bin/bash -c ". /opt/ros/${ROSDIST}/setup.bash && cd vrx_ws && GZ_VERSION=garden colcon build --merge-install"
 
 # Source all the needed environment files.
-RUN /bin/sh -c 'echo ". /opt/ros/${DIST}/setup.bash" >> ~/.bashrc' \
- && /bin/sh -c 'echo ". /usr/share/gazebo/setup.sh" >> ~/.bashrc' \
- && /bin/sh -c 'echo ". ~/vrx_ws/devel/setup.sh" >> ~/.bashrc'
+RUN /bin/sh -c 'echo ". /opt/ros/${ROSDIST}/setup.bash" >> ~/.bashrc' \
+ && /bin/sh -c 'echo ". ~/vrx_ws/install/setup.sh" >> ~/.bashrc'
 ## END OF SECTION BASED ON vrx/docker/Dockerfile
 
 # Expose port used to communiate with gzserver
 EXPOSE 11345
-
-# Stuff for nvidia-docker
-LABEL com.nvidia.volumes.needed="nvidia_driver"
-ENV PATH /usr/local/nvidia/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
-
-# Set encoding to use unicode characters
-# RUN sudo locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # setup entrypoint
 COPY ./vrx_entrypoint.sh /

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASEIMG
 ARG ROSDIST=humble
 
 # Create workspace
-RUN mkdir -p vrx_ws/src
+RUN mkdir -p ~/vrx_ws/src
 
 # TODO: restore version tag
 RUN git clone https://github.com/osrf/vrx.git \

--- a/vrx_server/vrx-server/vrx_entrypoint.sh
+++ b/vrx_server/vrx-server/vrx_entrypoint.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -e
 
-# first, execute overriden entrypoint from gazebo
-source "/usr/share/gazebo/setup.sh"
-
 # setup ros environment.
-source "/opt/ros/noetic/setup.bash" > /dev/null
+source "/opt/ros/humble/setup.bash" > /dev/null
 
 # setup vrx environment
 source ~/vrx_ws/devel/setup.sh


### PR DESCRIPTION
This update should make it possible to build the vrx-server image with the VRX 2.0.0 release. To test, build the image and make sure it can launch a task.

## Step 1: Build
```
 ./vrx_server/build_image.bash
```
from the root of the repository and verify that it builds. Further work is needed before we can test that it is working correctly (for example, it would be helpful to build a new example image that uses VRX 2.0.0, and the instructions for running a trial need to be updated).

## Step 2: Launch a task
* Bring up the vrx-server container manually.
    ```
  SERVER_IMG=vrx-server-jammy
  ./vrx_server/run_container.bash -n vrx-server-system $SERVER_IMG   "-it --entrypoint /bin/bash"
  ```

* Source the environment.
  ```
  source /opt/ros/humble/setup.bash
  cd vrx_ws
  . install/setup.bash
  ```
* Launch a task:
  ```
  ros2 launch vrx_gz competition.launch.py world:=stationkeeping_task
  ```
  Note that this may take a long time the first time you do it because the container needs to download all the models from fuel.


### EDIT: 
Moving the note below to the top comment for convenience.

@caguero This should now be ready for review. The teleop does not seem to be working but I will address that separately. The WAMV does respond to thrust commands published directly to `/wamv/thrusters/', e.g.

ros2 topic pub /wamv/thrusters/right/thrust std_msgs/msg/Float64 "data: 10.0" 
I'm not sure why but to produce detectable motion the data values have to be much higher than what used to be required.

### EDIT: 
teleop seems to be working now:
```
ros2 launch vrx_gz usv_joy_teleop.py
```
Allows me to control the usv as expected. It may be that the problem was with my host machine. After a recent set of updates and a reboot it started working again.