### PR TITLE
Gz build image patch

### DIFF
--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -18,7 +18,7 @@ RUN /bin/bash -c ". /opt/ros/${ROSDIST}/setup.bash && cd vrx_ws && GZ_VERSION=ga
 
 # Source all the needed environment files.
 RUN /bin/sh -c 'echo ". /opt/ros/${ROSDIST}/setup.bash" >> ~/.bashrc' \
- && /bin/sh -c 'echo ". ~/vrx_ws/install/setup.sh" >> ~/.bashrc'
+ && /bin/sh -c 'echo ". /home/developer/vrx_ws/install/setup.sh" >> ~/.bashrc'
 ## END OF SECTION BASED ON vrx/docker/Dockerfile
 
 # Expose port used to communiate with gzserver

--- a/vrx_server/vrx-server/vrx_entrypoint.sh
+++ b/vrx_server/vrx-server/vrx_entrypoint.sh
@@ -2,13 +2,13 @@
 set -e
 
 # first, execute overriden entrypoint from gazebo
-source "/usr/share/gazebo/setup.sh"
+# source "/usr/share/gazebo/setup.sh"
 
 # setup ros environment.
-source "/opt/ros/noetic/setup.bash" > /dev/null
+source "/opt/ros/humble/setup.bash" > /dev/null
 
 # setup vrx environment
-source ~/vrx_ws/devel/setup.sh
+source /home/developer/vrx_ws/devel/setup.sh
 echo "vrx entrypoint executed"
 
 # TODO: optionally disable this so a gzclient can be run on the host for development.


### PR DESCRIPTION
I tried to run the current configuration but encountered some issues that i solved with these changes.

- I made path to `vrx_ws/install/setup.sh` absolute because `~` resolves to `/root` not `/home/developer/`
- source `/opt/ros/humble/setup.bash` instead of `/opt/ros/noetic/setup.bash`
- don't source `/usr/share/gazebo/setup.sh` because cannot be found. 
  - not necessary any more with gazebo garden from base image?
