### PR TITLE
Update vrx_entrypoint.sh

### DIFF
--- a/vrx_server/vrx-server/vrx_entrypoint.sh
+++ b/vrx_server/vrx-server/vrx_entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 source "/opt/ros/humble/setup.bash" > /dev/null
 
 # setup vrx environment
-source ~/vrx_ws/devel/setup.sh
+source ~/vrx_ws/install/setup.sh
 echo "vrx entrypoint executed"
 
 # TODO: optionally disable this so a gzclient can be run on the host for development.


### PR DESCRIPTION
When i run 

- `./vrx_server/run_container.bash vrx-server-jammy vrx-server-jammy` 

after 

- `./vrx_server/build_image.bash` 

I get the following Error message:

- `/vrx_entrypoint.sh: line 11: /home/developer/vrx_ws/devel/setup.sh: No such file or directory`

When I change the path as suggested the error message does not show anymore.