### PR TITLE
updating prepare_team_wamv.bash to expect ros 2

### DIFF
--- a/prepare_team_wamv.bash
+++ b/prepare_team_wamv.bash
@@ -85,7 +85,7 @@ mkdir -p ${wamv_target_dir}
 
 # Generate WAM-V
 echo "Generating WAM-V..."
-roslaunch vrx_gazebo generate_wamv.launch component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
+ros2 launch vrx_gazebo generate_wamv.launch.py component_yaml:=$COMPONENT_CONFIG thruster_yaml:=$THRUSTER_CONFIG wamv_target:=$wamv_target wamv_locked:=true
 echo -e "${GREEN}OK${NOCOLOR}\n"
 
 # Write to text file about compliance


### PR DESCRIPTION
We are stuck troubleshooting #55 because the docker image isn't working. Initially, a minor update to `prepare_team_wamv.bash` was included as part of that PR. However, this update does not depend on the Docker image, and is needed for our validation process to work, so I have split it into a separate PR.

To test, please follow the [validation tutorial](https://github.com/osrf/vrx/wiki/vrx_2023-validation) using `TEAM=example_team`.