### PR TITLE
adding tag to use v2.3.1 when building the vrx server

### DIFF
--- a/vrx_server/build_image.bash
+++ b/vrx_server/build_image.bash
@@ -37,12 +37,13 @@ then
     exit 1
 fi
 
+# Use rocker to build a localized base image
 ROCKER_ARGS="--dev-helpers --devices $JOY --nvidia --x11 --user --user-override-name=developer  --image-name $local_base_name"
 rocker ${ROCKER_ARGS} npslearninglab/watery_robots:vrx_base "echo -e '${GREEN}Created $local_base_name.${NOCOLOR}\n'"
 
 CONTAINER_NAME="vrx-server-system"
 
-# Build image
+# Use Docker / Dockerfile to build server from localized base image
 echo "Building image: <${image_name}> from <$local_base_name>"
 set -x
 image_plus_tag=${image_name}:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)

--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -8,7 +8,7 @@ ARG ROSDIST=humble
 RUN mkdir -p ~/vrx_ws/src
 
 # TODO: restore version tag
-RUN git clone https://github.com/osrf/vrx.git \
+RUN git clone --depth 1 -b 2.3.1 https://github.com/osrf/vrx.git \
 && mv ./vrx ~/vrx_ws/src
 
 # Compile the VRX project.


### PR DESCRIPTION
Now that the final competition code is released, this resolves issue #64 by modifying the Dockerfile so we are always building from this version of the code.

To test:
* Run through the [testing tutorial](https://github.com/osrf/vrx/wiki/vrx_2023-testing) and make sure it rebuilds the vrx-server image and still works.

Bonus: added some explanatory comments to `buid_image.bash` because we are doing something a little unusual there.