### PR TITLE
Update run_one_team_one_task.bash

### DIFF
--- a/multi_scripts/run_one_team_one_task.bash
+++ b/multi_scripts/run_one_team_one_task.bash
@@ -2,7 +2,7 @@
 
 # run_one_team_one_task.bash: A bash script that calls run_trial.bash on all trials in task_generated
 #
-# eg. ./run_one_team_one_task.bash example_team station_keeping
+# eg. ./run_one_team_one_task.bash example_team stationkeeping
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -52,12 +52,12 @@ trial_DIR=${DIR}/../generated/task_generated/${TASK_NAME}/worlds/
 # Get the available trial numbers from the trial directory
 get_list_of_trial_nums()
 {
-  world_files=$(ls ${trial_DIR}/*.world)
+  world_files=$(ls ${trial_DIR}/*.sdf)
 
-  for f in $(ls ${trial_DIR}/*.world); do
+  for f in $(ls ${trial_DIR}/*.sdf); do
     f=${f##*/}
-    f=${f//.world}
-    f=${f//world}
+    f=${f//.sdf}
+    f=${f//sdf}
     all_trial_nums="${all_trial_nums} ${f}"
   done
 

--- a/vrx_server/vrx-server/run_vrx_trial.sh
+++ b/vrx_server/vrx-server/run_vrx_trial.sh
@@ -40,7 +40,7 @@ echo "Starting vrx trial..."
 # Run the trial.
 # Note: Increase record period to have faster playback. Decrease record period for slower playback
 RECORD_PERIOD="0.01"
-ros2 launch vrx_gz competition.launch.py headless:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gz_args:="--record_period ${RECORD_PERIOD} --record_path /home/developer/.gazebo --log_overwrite" verbose:=true non_competition_mode:=false > ~/verbose_output.txt 2>&1 &
+ros2 launch vrx_gz competition.launch.py headless:=false urdf:=$WAMV_URDF world:=$TRIAL_WORLD extra_gz_args:="--record_period ${RECORD_PERIOD} --record_path /home/developer/.gazebo --log_overwrite" verbose:=true competition_mode:=true > ~/verbose_output.txt 2>&1 &
 roslaunch_pid=$!
 wait_until_gzserver_is_up
 echo -e "${GREEN}OK${NOCOLOR}\n"


### PR DESCRIPTION
As part of its job, this scripts check  the available world files. It's still using the `.world` old suffix. This patch updates the code to use the current `.sdf` suffix.

Bonus: I enabled the competition mode to avoid access to debugging topics.

### How to test it?

Run through the [testing tutorial](https://github.com/osrf/vrx/wiki/vrx_2023-testing) and run the simulation with:

```
./multi_scripts/run_one_team_one_task.bash example_team stationkeeping
```

If you want to check for debugging topics, first get your container ID:

```
docker container ls
```

Search for something similar to this:
```
CONTAINER ID   IMAGE
5cfcd085a2de   jessicaherman/vrx-competitor-example:2023.v2
```

Enter into the running container:
```
docker exec -it 5cfcd085a2de bash
```

Source the ROS 2 `setup.bash` and check for topics:
```
root@5cfcd085a2de:/# . /opt/ros/humble/setup.bash 
root@5cfcd085a2de:/# ros2 topic list
```

You shouldn't see these debugging topics:
```
/vrx/debug/wind/direction
/vrx/debug/wind/speed

```
