### PR TITLE
Remove pinned version

### DIFF
--- a/vrx_server/vrx-server/Dockerfile
+++ b/vrx_server/vrx-server/Dockerfile
@@ -8,7 +8,7 @@ ARG ROSDIST=humble
 RUN mkdir -p ~/vrx_ws/src
 
 # TODO: restore version tag
-RUN git clone --depth 1 -b 2.3.1 https://github.com/osrf/vrx.git \
+RUN git clone --depth 1 https://github.com/osrf/vrx.git \
 && mv ./vrx ~/vrx_ws/src
 
 # Compile the VRX project.


### PR DESCRIPTION
This patch removes the pinned version (`2.3.1`) when building the VRX server Docker image. We need a few bug fixes that are merged after `2.3.1`.